### PR TITLE
add CAR_HASH_CODE preference. fixes #180

### DIFF
--- a/org.envirocar.app.test/src/org/envirocar/app/test/CarManagerTest.java
+++ b/org.envirocar.app.test/src/org/envirocar/app/test/CarManagerTest.java
@@ -26,6 +26,7 @@ import org.envirocar.app.activity.SettingsActivity;
 import org.envirocar.app.activity.preference.CarSelectionPreference;
 import org.envirocar.app.application.CarManager;
 import org.envirocar.app.model.Car;
+import org.envirocar.app.model.Car.FuelType;
 
 import android.content.SharedPreferences;
 import android.preference.PreferenceManager;
@@ -49,5 +50,9 @@ public class CarManagerTest extends AndroidTestCase {
 					carObject);
 		} 
 
+		Car c1 = new Car(FuelType.DIESEL, "test", "test", "test", 1234, 1);
+		Car c2 = new Car(FuelType.GASOLINE, "test", "test", "test", 1234, 1);
+		
+		Assert.assertTrue("HashCodes of different car objects were the same!", c1.hashCode() != c2.hashCode());
 	}
 }

--- a/org.envirocar.app/src/org/envirocar/app/activity/DashboardFragment.java
+++ b/org.envirocar.app/src/org/envirocar/app/activity/DashboardFragment.java
@@ -185,7 +185,7 @@ public class DashboardFragment extends SherlockFragment {
 			@Override
 			public void onSharedPreferenceChanged(SharedPreferences sharedPreferences,
 					String key) {
-				if (key.equals(SettingsActivity.CAR)) {
+				if (key.equals(SettingsActivity.CAR) || key.equals(SettingsActivity.CAR_HASH_CODE)) {
 					updateSensorOnDashboard();
 				}
 			}

--- a/org.envirocar.app/src/org/envirocar/app/activity/MainActivity.java
+++ b/org.envirocar.app/src/org/envirocar/app/activity/MainActivity.java
@@ -204,8 +204,10 @@ public class MainActivity<AndroidAlarmService> extends SherlockFragmentActivity 
 		// font stuff
 		actionBarTitleID = Utils.getActionBarId();
 		if (Utils.getActionBarId() != 0) {
-			((TextView) this.findViewById(actionBarTitleID))
-					.setTypeface(TypefaceEC.Newscycle(this));
+			TextView view = (TextView) this.findViewById(actionBarTitleID);
+			if (view != null) {
+				view.setTypeface(TypefaceEC.Newscycle(this));
+			}
 		}
 
 		actionBar.setLogo(getResources().getDrawable(R.drawable.actionbarlogo_with_padding));
@@ -298,7 +300,7 @@ public class MainActivity<AndroidAlarmService> extends SherlockFragmentActivity 
 				if (key.equals(SettingsActivity.BLUETOOTH_NAME)) {
 					updateStartStopButton();
 				}
-				else if (key.equals(SettingsActivity.CAR)) {
+				if (key.equals(SettingsActivity.CAR) || key.equals(SettingsActivity.CAR_HASH_CODE)) {
 					updateStartStopButton();
 				}
 			}

--- a/org.envirocar.app/src/org/envirocar/app/activity/SettingsActivity.java
+++ b/org.envirocar.app/src/org/envirocar/app/activity/SettingsActivity.java
@@ -62,8 +62,8 @@ public class SettingsActivity extends SherlockPreferenceActivity {
 	public static final String DISPLAY_STAYS_ACTIV = "pref_display_always_activ";
 	public static final String IMPERIAL_UNIT = "pref_imperial_unit";
 	public static final String OBFUSCATE_POSITION = "pref_privacy";
-	public static final String ENGINE_DISPLACEMENT = "pref_engine_displacement";
 	public static final String CAR = "pref_selected_car";
+	public static final String CAR_HASH_CODE = "pref_selected_car_hash_code";
 	
 	private Preference about;
 	

--- a/org.envirocar.app/src/org/envirocar/app/activity/preference/CarSelectionPreference.java
+++ b/org.envirocar.app/src/org/envirocar/app/activity/preference/CarSelectionPreference.java
@@ -551,9 +551,10 @@ public class CarSelectionPreference extends DialogPreference {
 	}
 	
 	private void persistCar() {
+		CarManager.instance().setCar(car);
 		persistString(serializeCar(car));
+		getSharedPreferences().edit().putInt(SettingsActivity.CAR_HASH_CODE, car.hashCode()).commit();
         setSummary(car.toString());	
-        CarManager.instance().setCar(car);
 	}
 
 	@Override

--- a/org.envirocar.app/src/org/envirocar/app/application/CarManager.java
+++ b/org.envirocar.app/src/org/envirocar/app/application/CarManager.java
@@ -53,8 +53,8 @@ public class CarManager {
 			@Override
 			public void onSharedPreferenceChanged(SharedPreferences sharedPreferences,
 					String key) {
-				if (key.equals(SettingsActivity.CAR)) {
-					car = CarSelectionPreference.instantiateCar(preferences.getString(SettingsActivity.CAR, null));
+				if (key.equals(SettingsActivity.CAR) || key.equals(SettingsActivity.CAR_HASH_CODE)) {
+					setCar(CarSelectionPreference.instantiateCar(preferences.getString(SettingsActivity.CAR, null)));
 				}
 			}
 		});
@@ -78,6 +78,9 @@ public class CarManager {
 	}
 	
 	public void setCar(Car c) {
+		if (c == null) {
+			return;
+		}
 		this.car = c;
 	}
 


### PR DESCRIPTION
the long base64 serialized strings only differ a minor bit. obviously
Android SharedPreferences did not fire a change event due to that. This
is why an additional pref was required.
