### PR TITLE
Fixed the issue #324 by updating Gradle version, Gradle plugin, raising target SDK version

### DIFF
--- a/android-obd-simulator/AndroidManifest.xml
+++ b/android-obd-simulator/AndroidManifest.xml
@@ -17,7 +17,7 @@
       package="org.envirocar.obd"
       android:versionCode="1"
       android:versionName="1.0">
-    <uses-sdk android:minSdkVersion="10" android:targetSdkVersion="18" />
+
     <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
     <uses-permission android:name="android.permission.BLUETOOTH" />
 

--- a/android-obd-simulator/build.gradle
+++ b/android-obd-simulator/build.gradle
@@ -6,7 +6,6 @@ dependencies {
 
 android {
     compileSdkVersion 27
-    buildToolsVersion "27.0.3"
 
     sourceSets {
         main {
@@ -30,5 +29,9 @@ android {
         // by a similar customization.
         debug.setRoot('build-types/debug')
         release.setRoot('build-types/release')
+    }
+    defaultConfig {
+        minSdkVersion 10
+        targetSdkVersion 18
     }
 }

--- a/android-obd-simulator/build.gradle
+++ b/android-obd-simulator/build.gradle
@@ -31,7 +31,7 @@ android {
         release.setRoot('build-types/release')
     }
     defaultConfig {
-        minSdkVersion 10
-        targetSdkVersion 18
+        minSdkVersion 16
+        targetSdkVersion 28
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -37,8 +37,8 @@ allprojects {
 ext {
     androidPlugin = 'com.android.tools.build:gradle:3.1.2'
     minSdkVersion = 16
-    compileSdkVersion = 27
-    targetSdkVersion = 27
+    compileSdkVersion = 28
+    targetSdkVersion = 28
     buildToolsVersion = '27.0.3'
     versionCode = 34
     versionName = "0.22.5"

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.3'
+        classpath 'com.android.tools.build:gradle:3.3.1'
         classpath "gradle.plugin.nl.javadude.gradle.plugins:license-gradle-plugin:0.12.1"
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri May 29 13:55:13 CEST 2015
+#Fri Mar 01 23:57:17 IST 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip

--- a/org.envirocar.algorithm/build.gradle
+++ b/org.envirocar.algorithm/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
-    buildToolsVersion rootProject.ext.buildToolsVersion
 
     compileOptions {
         sourceCompatibility rootProject.ext.javaCompileVersion

--- a/org.envirocar.app/AndroidManifest.xml
+++ b/org.envirocar.app/AndroidManifest.xml
@@ -5,10 +5,6 @@
     android:versionCode="34"
     android:versionName="0.22.5">
 
-    <uses-sdk
-        android:minSdkVersion="16"
-        android:targetSdkVersion="27" />
-
     <uses-feature
         android:name="android.hardware.bluetooth"
         android:required="true" />

--- a/org.envirocar.app/build.gradle
+++ b/org.envirocar.app/build.gradle
@@ -66,7 +66,6 @@ dependencies {
 
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
-    buildToolsVersion rootProject.ext.buildToolsVersion
 
     buildTypes {
         release {
@@ -118,5 +117,7 @@ android {
 
     defaultConfig {
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        minSdkVersion 16
+        targetSdkVersion 27
     }
 }

--- a/org.envirocar.core/build.gradle
+++ b/org.envirocar.core/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
-    buildToolsVersion rootProject.ext.buildToolsVersion
 
     compileOptions {
         sourceCompatibility rootProject.ext.javaCompileVersion

--- a/org.envirocar.obd/build.gradle
+++ b/org.envirocar.obd/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
-    buildToolsVersion rootProject.ext.buildToolsVersion
 
     compileOptions {
         sourceCompatibility rootProject.ext.javaCompileVersion

--- a/org.envirocar.remote/build.gradle
+++ b/org.envirocar.remote/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
-    buildToolsVersion rootProject.ext.buildToolsVersion
 
     compileOptions {
         sourceCompatibility rootProject.ext.javaCompileVersion

--- a/org.envirocar.storage/build.gradle
+++ b/org.envirocar.storage/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
-    buildToolsVersion rootProject.ext.buildToolsVersion
 
     compileOptions {
         sourceCompatibility rootProject.ext.javaCompileVersion


### PR DESCRIPTION
-> Upgraded the Gradle version, Plugin
-> Raised the target, compile SDK version. 
-> Handled the following error, warnings because of the upgrade:

- ERROR: The minSdk version should not be declared in the android manifest file. You can move the version from the manifest to the defaultConfig in the build.gradle file.
Move minSdkVersion to build files and sync project
Affected Modules: android-obd-simulator, org.envirocar.app


- WARNING: The specified Android SDK Build Tools version (27.0.3) is ignored, as it is below the minimum supported version (28.0.3) for Android Gradle Plugin 3.3.1.
Android SDK Build Tools 28.0.3 will be used.
To suppress this warning, remove "buildToolsVersion '27.0.3'" from your build.gradle file, as each version of the Android Gradle Plugin now has a default version of the build tools.
Remove Build Tools version and sync project
Affected Modules: android-obd-simulator, org.envirocar.algorithm, org.envirocar.app, org.envirocar.core, org.envirocar.obd, org.envirocar.remote, org.envirocar.storage


- WARNING: The targetSdk version should not be declared in the android manifest file. You can move the version from the manifest to the defaultConfig in the build.gradle file.
Move targetSdkVersion to build files and sync project
Affected Modules: android-obd-simulator, org.envirocar.app