### PR TITLE
Fix for app crashing when clicked on the card in local tracks #333

### DIFF
--- a/org.envirocar.app/src/org/envirocar/app/views/tracklist/TrackListLocalCardFragment.java
+++ b/org.envirocar.app/src/org/envirocar/app/views/tracklist/TrackListLocalCardFragment.java
@@ -75,7 +75,7 @@ public class TrackListLocalCardFragment extends AbstractTrackListCardFragment<
     @Override
     public void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        MainActivityComponent mainActivityComponent =  BaseApplication.get(getActivity()).getBaseApplicationComponent().plus(new MainActivityModule(getActivity()));
+        MainActivityComponent mainActivityComponent = BaseApplication.get(getActivity()).getBaseApplicationComponent().plus(new MainActivityModule(getActivity()));
         mainActivityComponent.inject(this);
     }
 
@@ -457,10 +457,9 @@ public class TrackListLocalCardFragment extends AbstractTrackListCardFragment<
                         @Override
                         public void onNext(List<Track> tracks) {
                             LOG.info(String.format("onNext(%s)", tracks.size()));
-
                             boolean newTrackAdded = false;
                             for (Track track : tracks) {
-                                if (!mTrackList.contains(track)) {
+                                if (!mTrackList.contains(track) && track.isFinished()) {
                                     mTrackList.add(track);
                                     newTrackAdded = true;
                                 }


### PR DESCRIPTION
Just added a check to see if the track is finished. If we want to show the track with current read measurements though the track isn't finished we can just see if the measurements are null instead of checking if the track is finished. Please let me know how you want it to be so that I can make appropriate changes. (Fix for issue no #333)