### PR TITLE
Fixed null pointer exception with Bluetooth adaptor while the app is closing 

### DIFF
--- a/org.envirocar.app/src/org/envirocar/app/handler/BluetoothHandler.java
+++ b/org.envirocar.app/src/org/envirocar/app/handler/BluetoothHandler.java
@@ -496,7 +496,7 @@ public class BluetoothHandler {
      */
     public void stopBluetoothDeviceDiscovery() {
         // Cancel discovery if it is discovering.
-        if (mBluetoothAdapter.isDiscovering()) {
+        if (mBluetoothAdapter != null && mBluetoothAdapter.isDiscovering()) {
             mBluetoothAdapter.cancelDiscovery();
             LOGGER.info("Bluetooth discovery cancled");
         }

--- a/org.envirocar.app/src/org/envirocar/app/services/AutomaticOBDTrackService.java
+++ b/org.envirocar.app/src/org/envirocar/app/services/AutomaticOBDTrackService.java
@@ -283,6 +283,8 @@ public class AutomaticOBDTrackService extends BaseInjectorService {
 
         // Close the corresponding notification.
         NotificationHandler.closeNotification();
+
+        //Stopping the bluetooth discovery
         mBluetoothHandler.stopBluetoothDeviceDiscovery();
     }
 


### PR DESCRIPTION
Please refer the below image for details. Fixed it by checking if the Bluetooth adapter is null while stopping discovery. 
![untitled](https://user-images.githubusercontent.com/22850179/54823974-854f0380-4ccf-11e9-9316-5bbb08acc450.gif)

**Stack Trace**:
Caused by: java.lang.NullPointerException: Attempt to invoke virtual method 'boolean android.bluetooth.BluetoothAdapter.isDiscovering()' on a null object reference
        at org.envirocar.app.handler.BluetoothHandler.stopBluetoothDeviceDiscovery(BluetoothHandler.java:499)
        at org.envirocar.app.services.AutomaticOBDTrackService.onDestroy(AutomaticOBDTrackService.java:288)
        at android.app.ActivityThread.handleStopService(ActivityThread.java:3697)
