### PR TITLE
Added functionality  to indicator clicked event

### DIFF
--- a/org.envirocar.app/src/org/envirocar/app/views/dashboard/DashboardFragment.java
+++ b/org.envirocar.app/src/org/envirocar/app/views/dashboard/DashboardFragment.java
@@ -24,6 +24,7 @@ import android.content.Intent;
 import android.graphics.Color;
 import android.graphics.PorterDuff;
 import android.os.Bundle;
+import android.provider.Settings;
 import android.transition.AutoTransition;
 import android.transition.ChangeBounds;
 import android.transition.Slide;
@@ -399,25 +400,29 @@ public class DashboardFragment extends BaseInjectorFragment {
     @OnClick(R.id.fragment_dashboard_indicator_car)
     protected void onCarIndicatorClicked() {
         LOG.info("Car Indicator clicked");
-        // TODO
+        Intent intent = new Intent(getActivity(), CarSelectionActivity.class);
+        getActivity().startActivity(intent);
     }
 
     @OnClick(R.id.fragment_dashboard_indicator_obd)
     protected void onObdIndicatorClicked() {
         LOG.info("OBD indicator clicked");
-        // TODO
+        Intent intent = new Intent(getActivity(), OBDSelectionActivity.class);
+        getActivity().startActivity(intent);
     }
 
     @OnClick(R.id.fragment_dashboard_indicator_bluetooth)
     protected void onBluetoothIndicatorClicked() {
         LOG.info("Bluetooth indicator clicked");
-        // TODO
+        Intent intent = new Intent(getActivity(), OBDSelectionActivity.class);
+        getActivity().startActivity(intent);
     }
 
     @OnClick(R.id.fragment_dashboard_indicator_gps)
     protected void onGPSIndicatorClicked() {
         LOG.info("GPS indicator clicked");
-        // TODO
+        Intent intent=new Intent(Settings.ACTION_LOCATION_SOURCE_SETTINGS);
+        getActivity().startActivity(intent);
     }
 
     @Subscribe


### PR DESCRIPTION
### Description
No functionality attached to on clicked all indicator event. In case of GPS indicator User have to explicitly open location GPS setting to enable location.

Fixes #387

### How Has This Been Tested?
Tested on android Mi A3.



