### PR TITLE
Added bluetooth re-scan option in OBD-II selection

### DIFF
--- a/org.envirocar.app/res/drawable/ic_refresh_black_24dp.xml
+++ b/org.envirocar.app/res/drawable/ic_refresh_black_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M17.65,6.35C16.2,4.9 14.21,4 12,4c-4.42,0 -7.99,3.58 -7.99,8s3.57,8 7.99,8c3.73,0 6.84,-2.55 7.73,-6h-2.08c-0.82,2.33 -3.04,4 -5.65,4 -3.31,0 -6,-2.69 -6,-6s2.69,-6 6,-6c1.66,0 3.14,0.69 4.22,1.78L13,11h7V4l-2.35,2.35z"/>
+</vector>

--- a/org.envirocar.app/res/layout/activity_obd_selection_fragment.xml
+++ b/org.envirocar.app/res/layout/activity_obd_selection_fragment.xml
@@ -80,6 +80,17 @@
                     android:maxHeight="20dp"
                     android:minHeight="10dp"
                     android:visibility="gone"/>
+
+                <ImageView
+                    android:id="@+id/activity_obd_selection_layout_rescan_bluetooth"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginRight="10dp"
+                    android:src="@drawable/ic_refresh_black_24dp"
+                    android:tint="@color/blue_light_cario"
+                    android:maxHeight="20dp"
+                    android:minHeight="10dp"/>
+
             </LinearLayout>
 
             <ListView

--- a/org.envirocar.app/src/org/envirocar/app/views/obdselection/OBDSelectionFragment.java
+++ b/org.envirocar.app/src/org/envirocar/app/views/obdselection/OBDSelectionFragment.java
@@ -50,6 +50,7 @@ import javax.inject.Inject;
 
 import butterknife.BindView;
 import butterknife.ButterKnife;
+import butterknife.OnClick;
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.observers.DisposableObserver;
@@ -142,6 +143,11 @@ public class OBDSelectionFragment extends BaseInjectorFragment {
         });
     }
 
+    @OnClick(R.id.activity_obd_selection_layout_rescan_bluetooth)
+    protected void rediscover() {
+        mBluetoothHandler.stopBluetoothDeviceDiscovery();
+        updateContentView();
+    }
     /**
      * Updates the content view.
      */


### PR DESCRIPTION
### Description
Added option to re-scan nearby bluetooth device.

Fixes #418  

- on refresh image icon click it stop the bluetooth discovery and then start bluetooth discovery again.
## Gif attached

<table>
<tr><th><h3>Added bluetooth rescan option<h3></th>
</tr>
<tr><td><img src="https://user-images.githubusercontent.com/33172321/74285937-c5d2c800-4d4c-11ea-8c00-a15ad6b5217f.gif"  height="600"/></td>

</tr>
</table>

## Tested on
android device :Mi A3.