### PR TITLE
fix on switch between gps and obd on RECORDING_INIT

### DIFF
--- a/org.envirocar.app/src/org/envirocar/app/views/dashboard/DashboardFragment.java
+++ b/org.envirocar.app/src/org/envirocar/app/views/dashboard/DashboardFragment.java
@@ -372,20 +372,25 @@ public class DashboardFragment extends BaseInjectorFragment {
 
         switch (this.modeSegmentedGroup.getCheckedRadioButtonId()) {
             case R.id.fragment_dashboard_obd_mode_button:
-                BluetoothDevice device = bluetoothHandler.getSelectedBluetoothDevice();
+                if (!this.gpsIndicator.isEnabled()
+                        && !this.carIndicator.isEnabled()
+                        && !this.bluetoothIndicator.isEnabled()
+                        && !this.obdIndicator.isEnabled()) {
+                    BluetoothDevice device = bluetoothHandler.getSelectedBluetoothDevice();
 
-                Intent obdRecordingIntent = new Intent(getActivity(), RecordingService.class);
-                this.connectingDialog = new MaterialDialog.Builder(getActivity())
-                        .iconRes(R.drawable.ic_bluetooth_searching_black_24dp)
-                        .title(R.string.dashboard_connecting)
-                        .content(String.format(getString(R.string.dashboard_connecting_find_template), device.getName()))
-                        .progress(true, 0)
-                        .negativeText(R.string.cancel)
-                        .cancelable(false)
-                        .onNegative((dialog, which) -> getActivity().stopService(obdRecordingIntent))
-                        .show();
+                    Intent obdRecordingIntent = new Intent(getActivity(), RecordingService.class);
+                    this.connectingDialog = new MaterialDialog.Builder(getActivity())
+                            .iconRes(R.drawable.ic_bluetooth_searching_black_24dp)
+                            .title(R.string.dashboard_connecting)
+                            .content(String.format(getString(R.string.dashboard_connecting_find_template), device.getName()))
+                            .progress(true, 0)
+                            .negativeText(R.string.cancel)
+                            .cancelable(false)
+                            .onNegative((dialog, which) -> getActivity().stopService(obdRecordingIntent))
+                            .show();
 
-                ContextCompat.startForegroundService(getActivity(), obdRecordingIntent);
+                    ContextCompat.startForegroundService(getActivity(), obdRecordingIntent);
+                }
                 break;
             case R.id.fragment_dashboard_gps_mode_button:
                 Intent gpsOnlyIntent = new Intent(getActivity(), RecordingService.class);


### PR DESCRIPTION
### Description
Fix app crash when user start GPStrack and switch mode in between before starting track (in RECORDIN_INIT state) .
App crashes because on switching between state the OBD track mode has not all parameters enabled but button is set to enabled so on click it throws Null Pointer Exception .

Fixes #425 
## Gif attached

<table>
<tr><th><h1>Error<h1></th>
<th><h1>Fix</h1></th>
</tr>
<tr><td><img src="https://user-images.githubusercontent.com/33172321/74613745-edec6d80-5136-11ea-9ecc-de8a154da8e9.gif"  height=500/></td>
<td><img src="https://user-images.githubusercontent.com/33172321/74613755-0d839600-5137-11ea-9cfd-499f06b03247.gif" height=500 /></td>
</tr>
</table>


