### PR TITLE
Add ripple effect to buttons

### DIFF
--- a/org.envirocar.app/res/drawable/others_item_background.xml
+++ b/org.envirocar.app/res/drawable/others_item_background.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ripple xmlns:android="http://schemas.android.com/apk/res/android"
+    android:color="#40000000">
+    <item android:id="@android:id/mask">
+        <shape android:shape="rectangle">
+            <solid android:color="@color/colorPrimaryDark" />
+        </shape>
+    </item>
+
+    <item android:id="@android:id/background">
+        <shape android:shape="rectangle">
+            <solid android:color="#FFFFFF" />
+        </shape>
+    </item>
+</ripple>

--- a/org.envirocar.app/res/drawable/ripple_button.xml
+++ b/org.envirocar.app/res/drawable/ripple_button.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ripple xmlns:android="http://schemas.android.com/apk/res/android"
+    android:color="#40000000">
+    <item android:id="@android:id/mask">
+        <shape android:shape="rectangle">
+            <solid android:color="@color/colorPrimaryDark" />
+        </shape>
+    </item>
+
+    <item android:id="@android:id/background">
+        <shape android:shape="rectangle">
+            <solid android:color="@color/cario_color_primary_dark" />
+        </shape>
+    </item>
+</ripple>

--- a/org.envirocar.app/res/layout/activity_signin.xml
+++ b/org.envirocar.app/res/layout/activity_signin.xml
@@ -105,7 +105,6 @@
             android:layout_marginTop="48dp"
             android:layout_marginEnd="55dp"
             android:layout_marginRight="55dp"
-            app:cardBackgroundColor="@color/cario_color_primary_dark"
             app:cardCornerRadius="25dp"
             app:cardElevation="10dp"
             app:layout_constraintEnd_toEndOf="parent"
@@ -113,6 +112,11 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/activity_login_password_input">
 
+            <ImageView
+                android:src="@drawable/ripple_button"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:scaleType="fitXY"/>
             <TextView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"

--- a/org.envirocar.app/res/layout/activity_signup.xml
+++ b/org.envirocar.app/res/layout/activity_signup.xml
@@ -187,6 +187,12 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/activity_signup_tou_text">
 
+            <ImageView
+                android:src="@drawable/ripple_button"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:scaleType="fitXY"/>
+
             <TextView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"

--- a/org.envirocar.app/res/layout/fragment_dashboard_view_new.xml
+++ b/org.envirocar.app/res/layout/fragment_dashboard_view_new.xml
@@ -685,6 +685,12 @@
                     app:layout_constraintStart_toStartOf="@id/guideline_settings_header_left"
                     app:layout_constraintTop_toBottomOf="@+id/fragment_dashboard_carselection_layout">
 
+                    <ImageView
+                        android:src="@drawable/ripple_button"
+                        android:layout_width="match_parent"
+                        android:layout_height="match_parent"
+                        android:scaleType="fitXY"/>
+
                     <androidx.appcompat.widget.AppCompatTextView
                         android:id="@+id/fragment_dashboard_start_track_button_text"
                         android:layout_width="match_parent"

--- a/org.envirocar.app/res/layout/fragment_others.xml
+++ b/org.envirocar.app/res/layout/fragment_others.xml
@@ -56,7 +56,9 @@
                 android:gravity="center"
                 android:id="@+id/othersLogBook"
                 android:padding="8dp"
-                android:orientation="horizontal">
+                android:orientation="horizontal"
+                android:background="@drawable/others_item_background"
+                >
 
                 <ImageView
                     android:layout_width="40dp"
@@ -75,7 +77,6 @@
                     android:layout_marginStart="15dp"
                     android:layout_marginEnd="10dp" />
 
-
             </LinearLayout>
 
             <View
@@ -90,7 +91,9 @@
                 android:gravity="center"
                 android:id="@+id/othersSettings"
                 android:padding="8dp"
-                android:orientation="horizontal">
+                android:orientation="horizontal"
+                android:background="@drawable/others_item_background"
+                >
 
                 <ImageView
                     android:layout_width="40dp"
@@ -125,7 +128,9 @@
                 android:gravity="center"
                 android:id="@+id/othersHelp"
                 android:padding="8dp"
-                android:orientation="horizontal">
+                android:orientation="horizontal"
+                android:background="@drawable/others_item_background"
+                >
 
                 <ImageView
                     android:layout_width="40dp"
@@ -158,7 +163,9 @@
                 android:gravity="center"
                 android:id="@+id/othersReportIssue"
                 android:padding="8dp"
-                android:orientation="horizontal">
+                android:orientation="horizontal"
+                android:background="@drawable/others_item_background"
+                >
 
                 <ImageView
                     android:layout_width="40dp"
@@ -191,7 +198,9 @@
                 android:gravity="center"
                 android:id="@+id/othersRateUs"
                 android:padding="8dp"
-                android:orientation="horizontal">
+                android:orientation="horizontal"
+                android:background="@drawable/others_item_background"
+                >
 
                 <ImageView
                     android:layout_width="40dp"
@@ -224,7 +233,9 @@
                 android:gravity="center"
                 android:id="@+id/othersLogOut"
                 android:padding="8dp"
-                android:orientation="horizontal">
+                android:orientation="horizontal"
+                android:background="@drawable/others_item_background"
+                >
 
                 <ImageView
                     android:layout_width="40dp"
@@ -258,7 +269,9 @@
                 android:gravity="center"
                 android:id="@+id/othersCloseEnviroCar"
                 android:padding="8dp"
-                android:orientation="horizontal">
+                android:orientation="horizontal"
+                android:background="@drawable/others_item_background"
+                >
 
                 <ImageView
                     android:layout_width="40dp"


### PR DESCRIPTION
This PR is with respect to issue #476 . Earlier clicking on several buttons did not have the default ripple effect which made UI less user immersive. Now along with the background, a ripple to these buttons have been added.
Please check the screenshots attached. 

With ripple buttons look like: 
![WhatsApp Image 2020-02-26 at 9 03 05 PM](https://user-images.githubusercontent.com/41758822/75387690-9d65d480-58db-11ea-89c3-25491875af8a.jpeg) ![WhatsApp Image 2020-02-26 at 8 55 44 PM (1)](https://user-images.githubusercontent.com/41758822/75387661-9212a900-58db-11ea-83d9-905f9c37c948.jpeg) ![WhatsApp Image 2020-02-26 at 8 55 44 PM](https://user-images.githubusercontent.com/41758822/75387749-af477780-58db-11ea-8c89-85b8a3e3b35c.jpeg)