### PR TITLE
Added SeekBar to change width of PreviewChart (Track statistics)

### DIFF
--- a/org.envirocar.app/res/layout/activity_track_statistics_fragment.xml
+++ b/org.envirocar.app/res/layout/activity_track_statistics_fragment.xml
@@ -46,4 +46,14 @@
         android:layout_height="0dp"
         android:layout_weight="1"/>
 
+    <androidx.appcompat.widget.AppCompatSeekBar
+        android:id="@+id/activity_track_statistics_seekBar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="8dp"
+        android:layout_marginTop="8dp"
+        android:visibility="gone"
+        android:layout_alignParentRight="true"
+        android:layout_alignParentTop="true" />
+
 </tools:LinearLayout>

--- a/org.envirocar.app/src/org/envirocar/app/views/trackdetails/TrackStatisticsActivity.java
+++ b/org.envirocar.app/src/org/envirocar/app/views/trackdetails/TrackStatisticsActivity.java
@@ -25,12 +25,20 @@ import android.content.Intent;
 import android.location.Location;
 import android.os.Bundle;
 import androidx.annotation.Nullable;
+import androidx.appcompat.widget.AppCompatSeekBar;
 import androidx.appcompat.widget.Toolbar;
+
+import android.os.strictmode.WebViewMethodCalledOnWrongThreadViolation;
 import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.SeekBar;
+import android.widget.Toast;
+
+import com.google.android.material.snackbar.Snackbar;
+import com.mapbox.mapboxsdk.style.layers.Property;
 
 import org.envirocar.app.BaseApplicationComponent;
 import org.envirocar.app.R;
@@ -169,6 +177,9 @@ public class TrackStatisticsActivity extends BaseInjectorActivity {
         @BindView(R.id.activity_track_statistics_fragment_chart_preview)
         protected PreviewLineChartView mPreviewChart;
 
+        @BindView(R.id.activity_track_statistics_seekBar)
+        protected AppCompatSeekBar seekBar;
+
         private LineChartData mChartData;
         private LineChartData mPreviewChartData;
 
@@ -210,6 +221,31 @@ public class TrackStatisticsActivity extends BaseInjectorActivity {
                 }
             });
 
+            mPreviewChart.setOnLongClickListener(view -> {seekBar.setVisibility(View.VISIBLE);
+            return  true;
+            });
+
+            seekBar.setOnSeekBarChangeListener(new SeekBar.OnSeekBarChangeListener(){
+                @Override
+                public void onProgressChanged(SeekBar seekBar, int i, boolean b) {
+                    Viewport tempViewport = new Viewport(mChart.getMaximumViewport());
+                    i = ((int)Math.round(i/2))*2;
+                    seekBar.setProgress(i);
+                    float dx = tempViewport.width()/i*10;
+                    tempViewport.inset(dx, 0);
+                    mPreviewChart.setCurrentViewportWithAnimation(tempViewport);
+                }
+
+                @Override
+                public void onStartTrackingTouch(SeekBar seekBar) {
+
+                }
+
+                @Override
+                public void onStopTrackingTouch(SeekBar seekBar) {
+                    seekBar.setVisibility(View.GONE);
+                }
+            });
             return rootView;
         }
 


### PR DESCRIPTION
## Description
 Control the area to be viewed in TrackStatisticsActivity PreviewChart  using seekbar which is earlier based on only two finger control zoom. Seek bar visible on long press event in PreviewChart and hide on stopTrackingTouch.

Fixes #453 

#### GIF attached.
<img src="https://user-images.githubusercontent.com/33172321/75612227-a1962a00-5b47-11ea-9922-be0ced10328f.gif"  height=500/>
