### PR TITLE
[FIX] Fix existing placeholder in Uploaded Track Fragment

### DIFF
--- a/org.envirocar.app/src/org/envirocar/app/views/tracklist/TrackListRemoteCardFragment.java
+++ b/org.envirocar.app/src/org/envirocar/app/views/tracklist/TrackListRemoteCardFragment.java
@@ -20,6 +20,7 @@ package org.envirocar.app.views.tracklist;
 
 import android.os.AsyncTask;
 import android.os.Bundle;
+import android.util.Log;
 import android.view.View;
 
 import androidx.annotation.Nullable;
@@ -177,6 +178,9 @@ public class TrackListRemoteCardFragment extends AbstractTrackListCardFragment<T
         if (mUserManager.isLoggedIn() && !tracksLoaded) {
             tracksLoaded = true;
             new LoadRemoteTracksTask().execute();
+        }
+        if (tracksLoaded && mUserManager.isLoggedIn()) {
+            updateView();
         }
     }
 


### PR DESCRIPTION
Solves issue #492 
The bug - Currently when you enter the track fragment for second time or later, the uploaded track screen remains empty instead of a placeholder, while it is seen for the first time. The problem arises due to the fact that the tracksLoaded data becomes true, hence updateView() method doesn't get called, hence no placeholder. To solve it I have added a small condition to check if tracksLoaded or not.

![WhatsApp Image 2020-03-10 at 2 03 58 PM](https://user-images.githubusercontent.com/41758822/76322434-4b5d7f80-62db-11ea-9eed-7b51ab8fcee0.jpeg)

@dewall sir please let me know if this solution is good and review my PR :))
