### PR TITLE
Fix overlapping password toggle and error icon

### DIFF
--- a/org.envirocar.app/res/drawable/ic_error_red_24dp.xml
+++ b/org.envirocar.app/res/drawable/ic_error_red_24dp.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#FF0000"
+    android:viewportHeight="24.0" android:viewportWidth="24.0"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#FF000000" android:pathData="M12,2C6.48,2 2,6.48 2,12s4.48,10 10,10 10,-4.48 10,-10S17.52,2 12,2zM13,17h-2v-2h2v2zM13,13h-2L11,7h2v6z"/>
+</vector>

--- a/org.envirocar.app/src/org/envirocar/app/views/login/SignupActivity.java
+++ b/org.envirocar.app/src/org/envirocar/app/views/login/SignupActivity.java
@@ -20,6 +20,7 @@ package org.envirocar.app.views.login;
 
 import android.content.Context;
 import android.content.Intent;
+import android.graphics.drawable.Drawable;
 import android.os.Bundle;
 import android.text.Selection;
 import android.text.Spannable;
@@ -78,6 +79,7 @@ public class SignupActivity extends BaseInjectorActivity {
     private static final String EMAIL_REGEX = "^[_A-Za-z0-9-\\+]+(\\.[_A-Za-z0-9-]+)*@[A-Za-z0-9-]+(\\.[A-Za-z0-9]+)*(\\.[A-Za-z]{2,})$";
     private static final String PASSWORD_REGEX = "^(?=.*?[A-Z])(?=.*?[a-z])(?=.*?[0-9]).{6,}$";
     private static final int CHECK_FORM_DELAY = 750;
+    private static Drawable error;
 
     public static void startActivity(Context context) {
         Intent intent = new Intent(context, SignupActivity.class);
@@ -128,6 +130,9 @@ public class SignupActivity extends BaseInjectorActivity {
 
         // inject the views
         ButterKnife.bind(this);
+
+        error = getResources().getDrawable(R.drawable.ic_error_red_24dp);
+        error.setBounds(-50,0,0,error.getIntrinsicHeight());
 
         // make terms of use and privacy statement clickable
         this.makeClickableTextLinks();
@@ -359,13 +364,13 @@ public class SignupActivity extends BaseInjectorActivity {
     private boolean checkPasswordValidity(String password) {
         boolean isValidPassword = true;
         if (password == null || password.isEmpty() || password.equals("")) {
-            password1EditText.setError(getString(R.string.error_field_required));
+            password1EditText.setError(getString(R.string.error_field_required),error);
             isValidPassword = false;
         } else if (password.length() < 6) {
-            password1EditText.setError(getString(R.string.error_invalid_password));
+            password1EditText.setError(getString(R.string.error_invalid_password),error);
             isValidPassword = false;
         } else if (!Pattern.matches(PASSWORD_REGEX, password)) {
-            password1EditText.setError(getString(R.string.error_field_weak_password));
+            password1EditText.setError(getString(R.string.error_field_weak_password),error);
             isValidPassword = false;
         } else {
             final String password2 = password2EditText.getText().toString().trim();
@@ -382,7 +387,7 @@ public class SignupActivity extends BaseInjectorActivity {
     private boolean checkConfirmPasswordValidity(String password2) {
         boolean isValidMatch = true;
         if (password2 == null || password2.isEmpty() || password2.equals("")) {
-            password2EditText.setError(getString(R.string.error_field_required));
+            password2EditText.setError(getString(R.string.error_field_required),error);
             isValidMatch = false;
         } else {
             final String password1 = password1EditText.getText().toString().trim();
@@ -399,8 +404,8 @@ public class SignupActivity extends BaseInjectorActivity {
     private boolean checkPasswordMatch(String password, String password2) {
         boolean isValidMatch = password.equals(password2);
         if (!isValidMatch) {
-            password1EditText.setError(getString(R.string.error_passwords_not_matching));
-            password2EditText.setError(getString(R.string.error_passwords_not_matching));
+            password1EditText.setError(getString(R.string.error_passwords_not_matching),error);
+            password2EditText.setError(getString(R.string.error_passwords_not_matching),error);
         } else {
             password1EditText.setError(null);
             password2EditText.setError(null);


### PR DESCRIPTION
### Description
Fix overlapping password toggle and error icon in SignUp in password edit text .

## Screenshot attached

<table>
<tr><th><h1>Error</h1></th>
<th><h1>Fix</h1></th>
</tr>
<tr><td><img src="https://user-images.githubusercontent.com/33172321/76827135-1d7cbb80-6844-11ea-8314-278310813db5.png"  height=500/></td>
<td><img src="https://user-images.githubusercontent.com/33172321/76827249-66347480-6844-11ea-8a04-8dd868c27b82.png" height=500 /></td>
</tr>
</table>