### PR TITLE
Fix username error on special symbol

### DIFF
--- a/org.envirocar.app/res/values/strings_activity_login.xml
+++ b/org.envirocar.app/res/values/strings_activity_login.xml
@@ -29,6 +29,7 @@
     <string name="register_progress_signing_in">Registering&#8230;</string>
     <string name="error_passwords_not_matching">The passwords do not match.</string>
     <string name="error_invalid_username">This username is too short.</string>
+    <string name="error_username_contain_special">Special symbol not allowed except underscore</string>
     <string name="error_field_weak_password">Password must contain at least one uppercase letter, one lowercase letter and one digit</string>
 
     <string name="error_username_already_in_use">This username is already in use.</string>

--- a/org.envirocar.app/src/org/envirocar/app/views/login/SignupActivity.java
+++ b/org.envirocar.app/src/org/envirocar/app/views/login/SignupActivity.java
@@ -77,6 +77,7 @@ public class SignupActivity extends BaseInjectorActivity {
 
     private static final String EMAIL_REGEX = "^[_A-Za-z0-9-\\+]+(\\.[_A-Za-z0-9-]+)*@[A-Za-z0-9-]+(\\.[A-Za-z0-9]+)*(\\.[A-Za-z]{2,})$";
     private static final String PASSWORD_REGEX = "^(?=.*?[A-Z])(?=.*?[a-z])(?=.*?[0-9]).{6,}$";
+    private static final String USERNAME_REGEX = "^[a-z0-9_-]{6,}$";
     private static final int CHECK_FORM_DELAY = 750;
 
     public static void startActivity(Context context) {
@@ -333,6 +334,9 @@ public class SignupActivity extends BaseInjectorActivity {
             isValidUsername = false;
         } else if (username.length() < 6) {
             usernameEditText.setError(getString(R.string.error_invalid_username));
+            isValidUsername = false;
+        } else if (!Pattern.matches(USERNAME_REGEX,username)) {
+            usernameEditText.setError(getString(R.string.error_username_contain_special));
             isValidUsername = false;
         }
         return isValidUsername;


### PR DESCRIPTION
#  Description
Username is reactive to the special symbol type in username and set error accordingly. Previously username is reactive only for the Length and empty but when on click in signUp  it show error Unable to communicate with server because of special symbol in username.

Fix #507 

## Regualr Expression
 <b>^[a-z0-9_-]{6,}$ </b>

## Gif attached
<img src = "https://user-images.githubusercontent.com/33172321/77037420-500aed80-69d7-11ea-86c8-4a0b71488a34.gif" height = 500/>