### PR TITLE
Correct calculation of diesel consumption

### DIFF
--- a/org.envirocar.core/src/main/java/org/envirocar/core/trackprocessing/consumption/DieselConsumptionAlgorithm.java
+++ b/org.envirocar.core/src/main/java/org/envirocar/core/trackprocessing/consumption/DieselConsumptionAlgorithm.java
@@ -101,7 +101,7 @@ public class DieselConsumptionAlgorithm implements ConsumptionAlgorithm {
         /**
          * calculate volumetric fuel flow in l/h
          */
-        return massFuelFlow * FUEL_DENSITY;
+        return massFuelFlow / FUEL_DENSITY;
     }
 
     private double resolveMassAirFlow(Measurement measurement) throws FuelConsumptionException {


### PR DESCRIPTION
Mass fuel flow should be divided by fuel density not multiplied with it.
Unit check: (kg/h) / (kg/l) = l/h.
The effect is small because the density value is close to 1 (0.832 kg/l).