### PR TITLE
Regex for username changed to allow uppercase letters #576

### DIFF
--- a/org.envirocar.app/src/org/envirocar/app/views/login/SignupActivity.java
+++ b/org.envirocar.app/src/org/envirocar/app/views/login/SignupActivity.java
@@ -78,7 +78,7 @@ public class SignupActivity extends BaseInjectorActivity {
 
     private static final String EMAIL_REGEX = "^[_A-Za-z0-9-\\+]+(\\.[_A-Za-z0-9-]+)*@[A-Za-z0-9-]+(\\.[A-Za-z0-9]+)*(\\.[A-Za-z]{2,})$";
     private static final String PASSWORD_REGEX = "^(?=.*?[A-Z])(?=.*?[a-z])(?=.*?[0-9]).{6,}$";
-    private static final String USERNAME_REGEX = "^[a-z0-9_-]{6,}$";
+    private static final String USERNAME_REGEX = "^[A-Za-z0-9_-]{6,}$";
     private static final int CHECK_FORM_DELAY = 750;
     private static Drawable error;
 


### PR DESCRIPTION
Regex for username changed allowing uppercase letters to be used in username.

Issue:
![WhatsApp Image 2021-03-11 at 10 09 24](https://user-images.githubusercontent.com/54644440/110836862-65ff6700-8255-11eb-8bec-f65c5632d541.jpeg)

Solved:
![WhatsApp Image 2021-03-11 at 10 35 23](https://user-images.githubusercontent.com/54644440/110836952-87605300-8255-11eb-8957-c2d2191d3214.jpeg)

