### PR TITLE
Minor Bug Fixes

### DIFF
--- a/org.envirocar.app/res/values-de/strings.xml
+++ b/org.envirocar.app/res/values-de/strings.xml
@@ -86,7 +86,7 @@
     <string name="report_issue_header">Fehler melden</string>
     <string name="report_issue_summary">Kurzbeschreibung</string>
     <string name="report_issue_time_since_crash">Ungefährer Zeitpunkt:</string>
-    <string name="report_issue_minutes">10:00</string>
+    <string name="report_issue_minutes">Standardzeit:10:00</string>
 
     <string name="report_issue_no_checkbox_selected_title">Keine Kategorie ausgewählt</string>
     <string name="report_issue_no_checkbox_selected_content">Sie haben keines der Kategorien markiert. Diese helfen jedoch den Entwicklern, Probleme zu kategorisieren und schneller zu lösen. Bitte erwägen Sie, die relevanten Felder auszufüllen.</string>

--- a/org.envirocar.app/res/values/strings.xml
+++ b/org.envirocar.app/res/values/strings.xml
@@ -107,7 +107,7 @@
     <string name="report_issue_header">Report an Issue</string>
     <string name="report_issue_summary">Summary of what went wrong</string>
     <string name="report_issue_time_since_crash">Estimated time</string>
-    <string name="report_issue_minutes">10:00</string>
+    <string name="report_issue_minutes">Default time:10:00</string>
 
     <string name="report_issue_no_checkbox_selected_title">No Checkbox Selected</string>
     <string name="report_issue_no_checkbox_selected_content">You have not selected any of the checkboxes. These help developers sort through issues quickly and resolve them. Please consider filling those that are relevant.</string>

--- a/org.envirocar.app/res/values/styles_login.xml
+++ b/org.envirocar.app/res/values/styles_login.xml
@@ -26,6 +26,7 @@
         <item name="android:layout_height">wrap_content</item>
         <item name="android:padding">4dp</item>
         <item name="android:textSize">20dp</item>
+        <item name="android:textCursorDrawable">@null</item>
         <item name="android:textColor">@color/white_cario</item>
         <item name="android:textColorHint">@color/white_cario_transparent</item>
         <item name="android:ems">10</item>


### PR DESCRIPTION
Fixes #592 
1. Login - Changed Edit text Curser color to white.

2. In Report Issue - Changed the hint (for now) to make the Estimated time value understandable. Need to update the appcompat_version above 1.2.0 to  use app:placeholderText which helps us to remove floating hint on edittext.


<img src="https://user-images.githubusercontent.com/70392921/111316397-3b644280-8689-11eb-9d27-66dc660fdb4b.png" width="250" height="500"/>

![Screenshot_20210316-183221](https://user-images.githubusercontent.com/70392921/111317342-11f7e680-868a-11eb-8181-8f0171e516e7.png)

