### PR TITLE
Fix #612: Bug: Email Validator in SignUp

### DIFF
--- a/org.envirocar.app/src/org/envirocar/app/views/login/SignupActivity.java
+++ b/org.envirocar.app/src/org/envirocar/app/views/login/SignupActivity.java
@@ -352,10 +352,10 @@ public class SignupActivity extends BaseInjectorActivity {
      */
     private boolean checkEmailValidity(String email) {
         boolean isValidEmail = true;
-        if (TextUtils.isEmpty(email)) {
+        if (TextUtils.isEmpty(email.trim())) {
             emailEditText.setError(getString(R.string.error_field_required));
             isValidEmail = false;
-        } else if (!Pattern.matches(EMAIL_REGEX, email)) {
+        } else if (!Pattern.matches(EMAIL_REGEX, email.trim())) {
             emailEditText.setError(getString(R.string.error_invalid_email));
             isValidEmail = false;
         }


### PR DESCRIPTION
Fix #612
**Changes Made**

Updated Email Validator Code.
Now front and last extra space are ignored during checking for validity of Email. Thus providing accurate result


<img src="https://user-images.githubusercontent.com/54978105/111487943-cc591d80-875e-11eb-9b5a-7adb57cf0277.jpg" width="333">