### PR TITLE
Fix #613: Bug: No checking for empty field in Confirm Password

### DIFF
--- a/org.envirocar.app/src/org/envirocar/app/views/login/SignupActivity.java
+++ b/org.envirocar.app/src/org/envirocar/app/views/login/SignupActivity.java
@@ -185,6 +185,9 @@ public class SignupActivity extends BaseInjectorActivity {
         if (!checkPasswordValidity(password1)) {
             focusView = password1EditText;
         }
+        if (!checkConfirmPasswordValidity(password2)) {
+            focusView = password2EditText;
+        }
         if (!checkEmailValidity(email)) {
             focusView = emailEditText;
         }


### PR DESCRIPTION
Fix #613 

**Changes Made**

Now a warning message will be shown if Confirm Password field is left empty as it is shown for other fields

<img src="https://user-images.githubusercontent.com/54978105/111491284-bc8f0880-8761-11eb-9d3d-a1e0cc0acdad.jpg" width="333">
