### PR TITLE
Fix #618: Bug: LogBook Add Fueling

### DIFF
--- a/org.envirocar.app/res/layout/activity_logbook_add_fueling_card.xml
+++ b/org.envirocar.app/res/layout/activity_logbook_add_fueling_card.xml
@@ -273,6 +273,8 @@
                         android:layout_height="wrap_content"
                         android:layout_marginRight="@dimen/spacing_large"
                         android:layout_weight="2"
+                        android:focusable="false"
+                        android:cursorVisible="false"
                         android:hint="0.00 €"
                         android:inputType="numberDecimal"/>
                 </LinearLayout>


### PR DESCRIPTION
Fix #618

Now Total Price field is calculated on entering fueled Volume and Price per liter automatically and user cannot mess up with the Total Price Feild

<img src="https://user-images.githubusercontent.com/54978105/111646385-9a5fbe00-8827-11eb-984a-fcfeed5777ea.jpg" width="333">