### PR TITLE
Fix #607 : No icon and content description in Logbook Fab

### DIFF
--- a/org.envirocar.app/res/layout/activity_logbook.xml
+++ b/org.envirocar.app/res/layout/activity_logbook.xml
@@ -129,9 +129,8 @@
     <com.google.android.material.floatingactionbutton.FloatingActionButton
         android:id="@+id/activity_logbook_toolbar_new_fueling_fab"
         style="@style/Widget.enviroCar.Fab"
-        android:layout_alignParentBottom="true"
-        android:layout_alignParentRight="true"
         android:layout_gravity="bottom|end"
-        android:layout_alignParentEnd="true" />
+        android:src="@drawable/ic_add_white_24dp"
+        android:contentDescription="@string/logbook_add_fueling" />
 
 </androidx.coordinatorlayout.widget.CoordinatorLayout>


### PR DESCRIPTION
Fix #607 

### Changes Made
Added new icon in the fab button to add fuelings with content description 

### Screenshots
![final](https://user-images.githubusercontent.com/41780639/111667587-df412000-883a-11eb-935a-6eaef7e52c76.jpg)
