### PR TITLE
Fix #625:Text not visible due to bad color scheme.

### DIFF
--- a/org.envirocar.app/res/layout/activity_signin.xml
+++ b/org.envirocar.app/res/layout/activity_signin.xml
@@ -147,6 +147,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginBottom="5dp"
+                android:textColor="@color/white_cario"
                 android:text="@string/not_yet_registered_question" />
 
             <TextView

--- a/org.envirocar.app/res/layout/activity_signup.xml
+++ b/org.envirocar.app/res/layout/activity_signup.xml
@@ -234,6 +234,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginBottom="5dp"
+                android:textColor="@color/white_cario"
                 android:text="@string/already_registered_question" />
 
             <TextView


### PR DESCRIPTION
TextView's color has been changed to white. Now it clearly visible and the UI looks decent.
![Screenshot 2021-03-19 at 2 16 49 AM](https://user-images.githubusercontent.com/43716674/111695495-2f2edf80-8859-11eb-94a2-1709796be9fd.png)
