### PR TITLE
Fixed #637 Number Picker Spacing and Selector line modified

### DIFF
--- a/org.envirocar.app/res/layout/preference_sampling_rate_dialog.xml
+++ b/org.envirocar.app/res/layout/preference_sampling_rate_dialog.xml
@@ -36,13 +36,17 @@
             android:layout_height="wrap_content"
             android:layout_marginLeft="5dip"
             android:focusable="true"
-            android:focusableInTouchMode="true" />
+            android:theme="@style/NumberPickerSelectorStyle"
+            android:focusableInTouchMode="true"
+            android:scrollbars="none"/>
 
         <TextView
+            android:layout_marginStart="4dp"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="center"
-            android:text="s" />
+            android:text="s"
+            android:textColor="#000"/>
 
     </LinearLayout>
 

--- a/org.envirocar.app/res/layout/preference_timepicker_dialog.xml
+++ b/org.envirocar.app/res/layout/preference_timepicker_dialog.xml
@@ -42,27 +42,35 @@
             android:layout_width="70dip"
             android:layout_height="wrap_content"
             android:focusable="true"
-            android:focusableInTouchMode="true" />
+            android:theme="@style/NumberPickerSelectorStyle"
+            android:focusableInTouchMode="true"
+            android:scrollbars="none"/>
 
         <TextView
+            android:layout_marginStart="4dp"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="center"
-            android:text="m " />
+            android:text="m "
+            android:textColor="#000"/>
 
         <NumberPicker
             android:id="@+id/preference_timepicker_seconds_picker"
             android:layout_width="70dip"
-            android:layout_height="wrap_content"
-            android:layout_marginLeft="5dip"
+            android:layout_height="match_parent"
+            android:layout_marginStart="10dip"
             android:focusable="true"
-            android:focusableInTouchMode="true" />
+            android:theme="@style/NumberPickerSelectorStyle"
+            android:focusableInTouchMode="true"
+            android:scrollbars="none"/>
 
         <TextView
+            android:layout_marginStart="4dp"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="center"
-            android:text="s" />
+            android:text="s"
+            android:textColor="#000"/>
 
     </LinearLayout>
 </LinearLayout>

--- a/org.envirocar.app/res/values/styles_envirocar.xml
+++ b/org.envirocar.app/res/values/styles_envirocar.xml
@@ -84,4 +84,7 @@
     <style name="DialogStyle" parent="Theme.AppCompat.Light.Dialog">
         <item name="colorAccent">@color/blue_dark_cario</item>
     </style>
+    <style name="NumberPickerSelectorStyle" parent="" >
+        <item name="colorControlNormal">@color/blue_dark_cario</item>
+    </style>
 </resources>


### PR DESCRIPTION
For now in this PR I have changed spacing between the number picker and added colours to selector lines. Also made scrollbar invisible so that number picker will look more consistent. I have not added spacing between the buttons as they are default DialogPreference buttons so to change I need to customise the dialog. For that firstly I need the permission of mentors if i can customise it and secondly as @asaikarthikeya want to make a consistent alert dialogs for whole app so if i customise the dialog now it can create conflicts.
@arvindnegi1 @bpross-52n Sir please let me know if I can use customise Dialog box or DialogPreference is used because of some reason.
If I can work then I will add another commit in this regarding the customise dialog box.