### PR TITLE
Fixed #661 Dialog dismiss after 10 seconds with a message.Added german translation

### DIFF
--- a/org.envirocar.app/res/values-de/strings_fragment_dashboard.xml
+++ b/org.envirocar.app/res/values-de/strings_fragment_dashboard.xml
@@ -30,6 +30,7 @@
 
     <string name="dashboard_connecting">Starte Aufzeichnung...</string>
     <string name="dashboard_connecting_find_template">Suche nach OBD \'%s\'.</string>
+    <string name="dashboard_connecting_not_found_template">unfähig zu finden \'%s\'. Bitte versuchen Sie es später noch einmal.</string>
     <string name="dashboard_connecting_found_template">\'%s\' gefunden. Stelle Verbindung her.</string>
 
     <string name="dashboard_recording_settings_header">Einstellungen</string>

--- a/org.envirocar.app/res/values/strings_fragment_dashboard.xml
+++ b/org.envirocar.app/res/values/strings_fragment_dashboard.xml
@@ -30,6 +30,7 @@
 
     <string name="dashboard_connecting">Connecting...</string>
     <string name="dashboard_connecting_find_template">Trying to find \'%s\'.</string>
+    <string name="dashboard_connecting_not_found_template">Unable to find \'%s\'. Please try again later.</string>
     <string name="dashboard_connecting_found_template">\'%s\' is in range. Trying to connect.</string>
 
     <string name="dashboard_recording_settings_header">Recording Settings</string>

--- a/org.envirocar.app/src/org/envirocar/app/views/dashboard/DashboardFragment.java
+++ b/org.envirocar.app/src/org/envirocar/app/views/dashboard/DashboardFragment.java
@@ -27,6 +27,7 @@ import android.content.pm.PackageManager;
 import android.graphics.Color;
 import android.graphics.PorterDuff;
 import android.os.Bundle;
+import android.os.CountDownTimer;
 import android.provider.Settings;
 import android.transition.AutoTransition;
 import android.transition.ChangeBounds;
@@ -453,6 +454,18 @@ public class DashboardFragment extends BaseInjectorFragment {
                                 .cancelable(false)
                                 .onNegative((dialog, which) -> getActivity().stopService(obdRecordingIntent))
                                 .show();
+
+                        new CountDownTimer(10000, 1000) {
+                            @Override
+                            public void onTick(long millisUntilFinished) {
+                            }
+                            @Override
+                            public void onFinish() {
+                                connectingDialog.dismiss();
+                                getActivity().stopService(obdRecordingIntent);
+                                Snackbar.make(getView(),String.format(getString(R.string.dashboard_connecting_not_found_template), device.getName()),Snackbar.LENGTH_LONG).show();
+                            }
+                        }.start();
 
                         ServiceUtils.startService(getActivity(), obdRecordingIntent);
                     }


### PR DESCRIPTION
Made dialog dismiss after 10 seconds when Start Track button is clicked with a Snackbar message of Unable to connect.