### PR TITLE
Fixed #682 New Feature : Adding dark theme to the app 

### DIFF
--- a/org.envirocar.app/res/values/strings.xml
+++ b/org.envirocar.app/res/values/strings.xml
@@ -82,7 +82,7 @@
 	    the OBD-II adapter. You could try to unplug and plug the adapter, then restart measurements.</string>
 
     <string name="general_error_please_report">General Track Error - Please report this issue</string>
-    <string name="Dark_Mode_Content" translatable="false" tools:ignore="MissingTranslation">Select the emtpy checkbox to enable dark theme</string>
+    <string name="Dark_Mode_Content" translatable="false" tools:ignore="MissingTranslation">Enable/Disable to view the app in dark/light mode</string>
 
 
 

--- a/org.envirocar.app/res/values/strings.xml
+++ b/org.envirocar.app/res/values/strings.xml
@@ -30,6 +30,11 @@
     <string name="sign_in">Sign In</string>
     <string name="sign_up">Sign Up</string>
     <string name="email">E-Mail</string>
+    <bool name="Force_dark">true</bool>
+
+
+    <string name="Dark_Theme" translatable="false" tools:ignore="MissingTranslation">Dark theme</string>
+    <string name="Dark_mode" translatable="false" tools:ignore="MissingTranslation">Dark-Mode</string>
 
 
     <string name="login_register">Login/Register</string>
@@ -77,6 +82,7 @@
 	    the OBD-II adapter. You could try to unplug and plug the adapter, then restart measurements.</string>
 
     <string name="general_error_please_report">General Track Error - Please report this issue</string>
+    <string name="Dark_Mode_Content" translatable="false" tools:ignore="MissingTranslation">Select the emtpy checkbox to enable dark theme</string>
 
 
 

--- a/org.envirocar.app/res/values/styles_envirocar.xml
+++ b/org.envirocar.app/res/values/styles_envirocar.xml
@@ -41,7 +41,7 @@
         <!--<item name="android:textColorSecondary">@color/white</item>-->
 
         <item name="alertDialogTheme">@style/DialogStyle</item>
-        <item name="android:forceDarkAllowed">true</item>
+        <item name="android:forceDarkAllowed">@bool/Force_dark</item>
     </style>
 
 

--- a/org.envirocar.app/res/values/styles_envirocar.xml
+++ b/org.envirocar.app/res/values/styles_envirocar.xml
@@ -41,6 +41,7 @@
         <!--<item name="android:textColorSecondary">@color/white</item>-->
 
         <item name="alertDialogTheme">@style/DialogStyle</item>
+        <item name="android:forceDarkAllowed">true</item>
     </style>
 
 


### PR DESCRIPTION
The current enviroCar app doesn't have the support for dark theme, So I had added dark theme support for the app (Issue #682).

**Sample Screenshots**
<img src="https://user-images.githubusercontent.com/73323807/113737953-1e68df80-971c-11eb-97db-b0aca6f7e3af.jpg" width="250"/>   <img src="https://user-images.githubusercontent.com/73323807/113737962-1f9a0c80-971c-11eb-9c40-4a4d0422feee.jpg" width="250"/>

<img src="https://user-images.githubusercontent.com/73323807/113737966-20cb3980-971c-11eb-9785-6948950ca4c7.jpg " width="250"/>    <img src="https://user-images.githubusercontent.com/73323807/113739965-eb275000-971d-11eb-8cb7-5f6949be5fd7.jpg" width="250"/>

@bpross-52n  and @arvindnegi1 please review the pull request.
