### PR TITLE
Added google playstore Rate this app Dialog prompt

### DIFF
--- a/org.envirocar.app/build.gradle
+++ b/org.envirocar.app/build.gradle
@@ -47,6 +47,8 @@ dependencies {
     implementation rootProject.ext.rxBindingCore
     implementation rootProject.ext.rxBindingAppCompat
 
+    implementation 'com.github.hotchemi:android-rate:1.0.1'
+
     // MapBox SDK
     implementation(rootProject.ext.mapbox) {
         transitive = true

--- a/org.envirocar.app/src/org/envirocar/app/views/dashboard/DashboardFragment.java
+++ b/org.envirocar.app/src/org/envirocar/app/views/dashboard/DashboardFragment.java
@@ -98,6 +98,8 @@ import butterknife.BindView;
 import butterknife.ButterKnife;
 import butterknife.OnCheckedChanged;
 import butterknife.OnClick;
+import hotchemi.android.rate.AppRate;
+import hotchemi.android.rate.OnClickButtonListener;
 import info.hoang8f.android.segmented.SegmentedGroup;
 import io.reactivex.Observable;
 import io.reactivex.android.schedulers.AndroidSchedulers;
@@ -210,10 +212,34 @@ public class DashboardFragment extends BaseInjectorFragment {
     @Override
     public void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+
+        setUpRateApp();
         // for the login/register button
         setHasOptionsMenu(true);
 
         this.disposables = new CompositeDisposable();
+    }
+
+    public void setUpRateApp()
+    {
+        AppRate.with(getActivity())
+                .setInstallDays(7) // Specifies the number of days after installation, the dialog popup shows.
+                .setLaunchTimes(2) // Specifies the number of times the app must launch by user for the dialog popup to show.
+                .setRemindInterval(3) // Specifies the number of days after "Remind Me Later" is clicked, the dialog popup will show.
+                .setShowLaterButton(true)
+                .setDebug(true) // IMPORTANT: Set true only for testing purposes. DO NOT set true for release-app.
+                .setOnClickButtonListener(new OnClickButtonListener() { // callback listener.
+                    @Override
+                    public void onClickButton(int which) {
+
+                        // Space to alter the entire functionality of the "dialog popup" for future purposes.
+
+                    }
+                })
+                .monitor();
+
+        //To show the dialog popup only if meets ALL specified conditions.
+        AppRate.showRateDialogIfMeetsConditions(getActivity());
     }
 
     @Nullable

--- a/org.envirocar.app/src/org/envirocar/app/views/dashboard/DashboardFragment.java
+++ b/org.envirocar.app/src/org/envirocar/app/views/dashboard/DashboardFragment.java
@@ -227,7 +227,7 @@ public class DashboardFragment extends BaseInjectorFragment {
                 .setLaunchTimes(2) // Specifies the number of times the app must launch by user for the dialog popup to show.
                 .setRemindInterval(3) // Specifies the number of days after "Remind Me Later" is clicked, the dialog popup will show.
                 .setShowLaterButton(true)
-                .setDebug(true) // IMPORTANT: Set true only for testing purposes. DO NOT set true for release-app.
+                .setDebug(false) // IMPORTANT: Set true only for testing purposes. DO NOT set true for release-app.
                 .setOnClickButtonListener(new OnClickButtonListener() { // callback listener.
                     @Override
                     public void onClickButton(int which) {


### PR DESCRIPTION
Fixes: #697

## Description:

Added a feature to automatically show a prompt to rate this app and to navigate to Google Playstore and also configured the prompt specifically for the release-app.
Currently, the Prompt shows when the app has been installed for a week AND has been launched atleast 2 times. If the user clicks "Remind me Later", the prompt will show up again only after 3 days.
The above configurations can be changed at anytime as Documented.

### Sample demo of Rate this app Dialog prompt:
![WhatsApp Video 2021-04-06 at 1 48 31 AM](https://user-images.githubusercontent.com/54114888/114209651-7f8eee00-997c-11eb-86df-6e1725af69e4.gif)

