### PR TITLE
Added update for AndroidX test Rules library

### DIFF
--- a/org.envirocar.app/build.gradle
+++ b/org.envirocar.app/build.gradle
@@ -67,7 +67,7 @@ dependencies {
     androidTestImplementation('androidx.test:runner:1.1.0-alpha4') {
         exclude module: 'support-annotations'
     }
-    androidTestImplementation('androidx.test:rules:1.1.0-alpha4') {
+    androidTestImplementation('androidx.test:rules:1.3.0') {
         exclude module: 'support-annotations'
     }
 


### PR DESCRIPTION
## Description:

Added update for the AndroidX test Rules library from version `1.1.0-alpha4` to its latest stable version `1.3.0` which was released on August 26, 2020. Also tested and verified on various scenarios while running the android application.