### PR TITLE
Scrollbar added for Help screen

### DIFF
--- a/org.envirocar.app/res/layout/activity_help_layout.xml
+++ b/org.envirocar.app/res/layout/activity_help_layout.xml
@@ -25,6 +25,10 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:clipToPadding="false"
+    android:scrollbars="vertical"
+    android:scrollbarSize="10sp"
+    android:scrollbarThumbVertical="@color/cario_color_primary"
+    android:fadeScrollbars="true"
     app:layout_behavior="@string/appbar_scrolling_view_behavior">
 
     <LinearLayout


### PR DESCRIPTION
Fixes: #703 

## Description:

Added scrollbar for help screen to easily get a glance on the amount of contents present on the screen. The scrollbar is not static/fixed. It fades away if not used for a few seconds. The scrollbar is a component of AndroidX and no 3rd party library is used which increases the compatibility of the component in the app.

### Sample demo of current Help screen:
![ezgif com-gif-maker (7)](https://user-images.githubusercontent.com/54114888/114218322-e6190980-9986-11eb-9aeb-7bded982349b.gif)


### Sample demo of Help screen with Scrollbar:
![ezgif com-gif-maker (6)](https://user-images.githubusercontent.com/54114888/114218109-9f2b1400-9986-11eb-9065-bd9f73b1e1b2.gif)
