### PR TITLE
Added Close enviroCar dialog box Icon

### DIFF
--- a/org.envirocar.app/res/drawable/ic_others_close_24.xml
+++ b/org.envirocar.app/res/drawable/ic_others_close_24.xml
@@ -1,0 +1,5 @@
+<vector android:height="36dp" android:tint="#FF0000"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="36dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M13,3h-2v10h2L13,3zM17.83,5.17l-1.42,1.42C17.99,7.86 19,9.81 19,12c0,3.87 -3.13,7 -7,7s-7,-3.13 -7,-7c0,-2.19 1.01,-4.14 2.58,-5.42L6.17,5.17C4.23,6.82 3,9.26 3,12c0,4.97 4.03,9 9,9s9,-4.03 9,-9c0,-2.74 -1.23,-5.18 -3.17,-6.83z"/>
+</vector>

--- a/org.envirocar.app/src/org/envirocar/app/views/others/OthersFragment.java
+++ b/org.envirocar.app/src/org/envirocar/app/views/others/OthersFragment.java
@@ -33,6 +33,7 @@ import android.widget.LinearLayout;
 
 import androidx.annotation.NonNull;
 import androidx.core.app.ActivityCompat;
+import androidx.core.content.ContextCompat;
 import androidx.fragment.app.Fragment;
 
 import com.afollestad.materialdialogs.MaterialDialog;
@@ -169,6 +170,7 @@ public class OthersFragment extends BaseInjectorFragment {
                 .positiveText(getString(R.string.menu_close_envirocar_positive))
                 .negativeText(getString(R.string.cancel))
                 .content(getString(R.string.menu_close_envirocar_content))
+                .icon(ContextCompat.getDrawable(getActivity(), R.drawable.ic_others_close_24))
                 .callback(new MaterialDialog.ButtonCallback() {
                     @Override
                     public void onPositive(MaterialDialog dialog) {


### PR DESCRIPTION
Fixes: #707 

## Description:

Added the respective Icon inside Close enviroCar dialog box which is triggered when a Button is clicked in Others fragment to improve the interactivity and user interface of the android app.

### Screenshot of current Close dialog box:
![WhatsApp Image 2021-04-08 at 12 41 07 AM](https://user-images.githubusercontent.com/54114888/114224209-698a2900-998e-11eb-9067-b4eeafa88729.jpeg)

### Screenshot of improved Close dialog box:
![WhatsApp Image 2021-04-08 at 12 52 16 AM](https://user-images.githubusercontent.com/54114888/114224766-2086a480-998f-11eb-8024-cafe7cc0b2d5.jpeg)
