### PR TITLE
Added update for Apache Commons library

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -115,7 +115,7 @@ ext {
     fabProgressCircle = 'com.github.jorgecastilloprz:fabprogresscircle:1.01'
     mapbox = 'com.mapbox.mapboxsdk:mapbox-android-sdk:8.1.0'
     segmentedUIController = 'info.hoang8f:android-segmented:1.0.6'
-    apacheCommons = 'org.apache.commons:commons-compress:1.18'
+    apacheCommons = 'org.apache.commons:commons-compress:1.20'
 
     // Testing
     junit = 'junit:junit:4.12'


### PR DESCRIPTION
## Description:

Added update for the Apache Commons Compress library from version `1.18` to the latest version `1.20` which was released on February 5th, 2020. Also tested and verified on various scenarios while running the android application. Apache Commons Compress library defines an API for working with compression and archive formats. These include: bzip2, gzip, pack200, lzma, xz, Snappy, traditional Unix Compress, DEFLATE, DEFLATE64, LZ4, Brotli, Zstandard and ar, cpio, jar, tar, zip, dump, 7z, arj.