### PR TITLE
Fixed Floating Action Button in logbook screen

### DIFF
--- a/org.envirocar.app/res/layout/activity_logbook.xml
+++ b/org.envirocar.app/res/layout/activity_logbook.xml
@@ -129,6 +129,7 @@
     <com.google.android.material.floatingactionbutton.FloatingActionButton
         android:id="@+id/activity_logbook_toolbar_new_fueling_fab"
         style="@style/Widget.enviroCar.Fab"
+        android:src="@drawable/ic_add_white_24dp"
         android:layout_alignParentBottom="true"
         android:layout_alignParentRight="true"
         android:layout_gravity="bottom|end"


### PR DESCRIPTION
Fixes: #721

## Description:

Added respective icon to the floating action button to enter new content on the Logbook screen.

## Screenshot of current Logbook screen:
![WhatsApp Image 2021-04-08 at 11 49 10 PM](https://user-images.githubusercontent.com/54114888/114247717-6f463580-99b3-11eb-9d6c-063682d7542b.jpeg)

## Screenshot of fixed Logbook screen:
![WhatsApp Image 2021-04-08 at 11 51 14 PM](https://user-images.githubusercontent.com/54114888/114247810-b6342b00-99b3-11eb-9dd7-7227557113e0.jpeg)
