### PR TITLE
Delete Entry dialog box Icon

### DIFF
--- a/org.envirocar.app/res/drawable/ic_delete_fueling_24.xml
+++ b/org.envirocar.app/res/drawable/ic_delete_fueling_24.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="36dp"
+    android:height="36dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M6,19c0,1.1 0.9,2 2,2h8c1.1,0 2,-0.9 2,-2L18,7L6,7v12zM8.46,11.88l1.41,-1.41L12,12.59l2.12,-2.12 1.41,1.41L13.41,14l2.12,2.12 -1.41,1.41L12,15.41l-2.12,2.12 -1.41,-1.41L10.59,14l-2.13,-2.12zM15.5,4l-1,-1h-5l-1,1L5,4v2h14L19,4z"
+      android:fillColor="#000000"/>
+</vector>

--- a/org.envirocar.app/src/org/envirocar/app/views/logbook/LogbookActivity.java
+++ b/org.envirocar.app/src/org/envirocar/app/views/logbook/LogbookActivity.java
@@ -21,6 +21,8 @@ package org.envirocar.app.views.logbook;
 import android.os.Bundle;
 import com.google.android.material.snackbar.Snackbar;
 import androidx.appcompat.widget.Toolbar;
+import androidx.core.content.ContextCompat;
+
 import android.view.View;
 import android.widget.AdapterView;
 import android.widget.ImageView;
@@ -136,6 +138,7 @@ public class LogbookActivity extends BaseInjectorActivity implements LogbookUiLi
                         .content(R.string.logbook_dialog_delete_fueling_content)
                         .positiveText(R.string.menu_delete)
                         .negativeText(R.string.cancel)
+                        .icon(ContextCompat.getDrawable(getApplicationContext(), R.drawable.ic_delete_fueling_24))
                         .onPositive((materialDialog, dialogAction) -> deleteFueling(fueling))
                         .show();
                 return false;


### PR DESCRIPTION
Fixes: #724

## Description:

Added the respective Icon inside Delete Fueling Entry dialog box which is triggered Logbook screen to improve the interactivity and user interface of the android app.

## Screenshot of current Dialog Box:
![WhatsApp Image 2021-04-09 at 12 54 22 AM](https://user-images.githubusercontent.com/54114888/114305596-6b6efc00-9af6-11eb-893b-a44a86b99344.jpeg)

## Screenshot of improved Dialog Box:
![WhatsApp Image 2021-04-09 at 1 09 33 AM](https://user-images.githubusercontent.com/54114888/114305649-bee14a00-9af6-11eb-8ff3-be7b445af833.jpeg)