### PR TITLE
Car selection card view Fixes #756

### DIFF
--- a/org.envirocar.app/src/org/envirocar/app/views/dashboard/DashboardFragment.java
+++ b/org.envirocar.app/src/org/envirocar/app/views/dashboard/DashboardFragment.java
@@ -547,6 +547,8 @@ public class DashboardFragment extends BaseInjectorFragment {
                 this.carIndicator.setEnabled(false);
             } else {
                 // set warning indicator color
+                this.carSelectionTextPrimary.setText(String.format("No car type selected"));
+                this.carSelectionTextSecondary.setText(String.format("Click here to select one"));
                 this.carIndicator.setEnabled(true);
             }
             this.updateStartTrackButton();


### PR DESCRIPTION
## DESCRIPTION
The current car card view does not get updated to default value in dashboard activity when a car is deleted from the car list. The bug is fixed now and it gets updated to the default value when no car is present in the list. I am attaching the videos before and after the problem is fixed.

Fixes #756

https://user-images.githubusercontent.com/77868296/123964532-22319880-d9d1-11eb-8dd0-f390e2e5d6ac.mp4


https://user-images.githubusercontent.com/77868296/123964556-2958a680-d9d1-11eb-8b96-1ff200232386.mp4

