### PR TITLE
Test: selector 

### DIFF
--- a/org.envirocar.app/res/color/dashboard_indicator_selector.xml
+++ b/org.envirocar.app/res/color/dashboard_indicator_selector.xml
@@ -20,6 +20,6 @@
 
 -->
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
-    <item android:color="@color/cario_color_primary_dark" android:state_enabled="false" />
-    <item android:color="@color/cario_warning_red" android:state_enabled="true" />
+    <item android:color="@color/cario_color_primary_dark" android:state_activated="false" />
+    <item android:color="@color/cario_warning_red" android:state_activated="true" />
 </selector>


### PR DESCRIPTION
- [x] I have changed `state_enabled` to `state_activated`
- [x]  DashboardFragment has `this.bluetoothIndicator.setEnabled(!event.isBluetoothEnabled);` for Bluetooth indicator
![Screenshot from 2021-07-21 16-05-12](https://user-images.githubusercontent.com/70392921/126475489-d57a77de-f792-49ec-85d4-236365f6d63f.png)

After the changes, the colour doesnot change as per selector. And onclick doesnot work.

https://user-images.githubusercontent.com/70392921/126475993-e928ac45-a4d0-486d-be44-22bf025ee701.mp4

