### PR TITLE
Sign in - set error message to confirm password.

### DIFF
--- a/org.envirocar.app/src/org/envirocar/app/views/login/SignupActivity.java
+++ b/org.envirocar.app/src/org/envirocar/app/views/login/SignupActivity.java
@@ -385,6 +385,8 @@ public class SignupActivity extends BaseInjectorActivity {
             final String password2 = password2EditText.getText().toString().trim();
             if (!password2.equals("") && !password2.isEmpty() && password2 != null) {
                 checkPasswordMatch(password, password2);
+            }else {
+                password2EditText.setError(getString(R.string.error_field_required), error);
             }
         }
         return isValidPassword;


### PR DESCRIPTION
Fixes #613 

Note - 
 We should not set error icon as that of other edittexts. Error icons should be only set if the password is entered. 