### PR TITLE
Sign in : handle error message when the entered username is wrong.

### DIFF
--- a/org.envirocar.app/res/values-de/strings_activity_login.xml
+++ b/org.envirocar.app/res/values-de/strings_activity_login.xml
@@ -26,6 +26,7 @@
     <string name="error_invalid_email">Email ist nicht valide</string>
     <string name="error_invalid_password">Zu kurzes Passwort</string>
     <string name="error_incorrect_password">Falsches Passwort</string>
+    <string name="error_invalid_credentials">Benutzername oder Passwort ist falsch</string>
     <string name="error_field_required">Benötigtes Feld</string>
     <string name="error_not_connected_to_network">Keine Verbindung zum Internet</string>
     <string name="register_progress_signing_in">Registerung&#8230;</string>

--- a/org.envirocar.app/res/values/strings_activity_login.xml
+++ b/org.envirocar.app/res/values/strings_activity_login.xml
@@ -24,6 +24,7 @@
     <string name="error_invalid_email">This email address is invalid.</string>
     <string name="error_invalid_password">This password is too short.</string>
     <string name="error_incorrect_password">This password is incorrect.</string>
+    <string name="error_invalid_credentials">Username or password is incorrect</string>
     <string name="error_field_required">This field is required.</string>
     <string name="error_not_connected_to_network">Not connected to network</string>
     <string name="register_progress_signing_in">Registering&#8230;</string>

--- a/org.envirocar.app/src/org/envirocar/app/exception/LoginException.java
+++ b/org.envirocar.app/src/org/envirocar/app/exception/LoginException.java
@@ -26,7 +26,7 @@ public class LoginException extends Exception {
     public enum ErrorType {
         MAIL_NOT_CONFIREMED,
         UNABLE_TO_COMMUNICATE_WITH_SERVER,
-        PASSWORD_INCORRECT
+        USERNAME_OR_PASSWORD_INCORRECT
     }
 
     private final ErrorType type;

--- a/org.envirocar.app/src/org/envirocar/app/handler/preferences/UserPreferenceHandler.java
+++ b/org.envirocar.app/src/org/envirocar/app/handler/preferences/UserPreferenceHandler.java
@@ -174,7 +174,9 @@ public class UserPreferenceHandler extends AbstractCachable<User> implements Use
                 emitter.onError(new LoginException(e.getMessage(), LoginException.ErrorType.MAIL_NOT_CONFIREMED));
             } catch (UnauthorizedException e) {
                 LOG.warn(e.getMessage(), e);
-                emitter.onError(new LoginException(e.getMessage(), LoginException.ErrorType.PASSWORD_INCORRECT));
+                // UnauthorizedException can be either due to Incorrect password, Incorrect Username or both.
+                // Hence, set error to both password and username
+                emitter.onError(new LoginException(e.getMessage(), LoginException.ErrorType.USERNAME_OR_PASSWORD_INCORRECT));
             } catch (Exception e) {
                 LOG.warn(e.getMessage(), e);
                 emitter.onError(e);

--- a/org.envirocar.app/src/org/envirocar/app/views/login/SigninActivity.java
+++ b/org.envirocar.app/src/org/envirocar/app/views/login/SigninActivity.java
@@ -208,8 +208,8 @@ public class SigninActivity extends BaseInjectorActivity {
                         if (e instanceof LoginException) {
                             switch (((LoginException) e).getType()) {
                                 case USERNAME_OR_PASSWORD_INCORRECT:
-                                    usernameEditText.setError("Username or password is incorrect");
-                                    passwordEditText.setError("Username or password is incorrect");
+                                    usernameEditText.setError(getString(R.string.error_invalid_credentials));
+                                    passwordEditText.setError(getString(R.string.error_invalid_credentials));
                                     break;
                                 case MAIL_NOT_CONFIREMED:
                                     // show alert dialog

--- a/org.envirocar.app/src/org/envirocar/app/views/login/SigninActivity.java
+++ b/org.envirocar.app/src/org/envirocar/app/views/login/SigninActivity.java
@@ -207,8 +207,9 @@ public class SigninActivity extends BaseInjectorActivity {
                         dialog.dismiss();
                         if (e instanceof LoginException) {
                             switch (((LoginException) e).getType()) {
-                                case PASSWORD_INCORRECT:
-                                    passwordEditText.setError(getString(R.string.error_incorrect_password));
+                                case USERNAME_OR_PASSWORD_INCORRECT:
+                                    usernameEditText.setError("Username or password is incorrect");
+                                    passwordEditText.setError("Username or password is incorrect");
                                     break;
                                 case MAIL_NOT_CONFIREMED:
                                     // show alert dialog


### PR DESCRIPTION
Fixes #483 

Current Implementation -

Check if username is registered -> Check password -> if wrong show error else login
if username is not registered then shown as password is incorrect. 

My Implementation - > 
We request user to recheck his both credentials. If password is wrong then also error is set to both.