### PR TITLE
Fix/missingFuelConsumption

### DIFF
--- a/org.envirocar.core/src/main/res/values-de/strings_property_keys.xml
+++ b/org.envirocar.core/src/main/res/values-de/strings_property_keys.xml
@@ -30,8 +30,8 @@
     <string name="property_key_engine_fuel_rate">Kraftstoffverbrauch</string>
     <string name="property_key_co2">CO\u2082</string>
     <string name="property_key_consumption">Geschätzter Verbrauch</string>
-    <string name="property_key_energy_consumption">Geschätzter Verbrauch</string>
-    <string name="property_key_energy_co2_emission">Geschätzte CO\u2082 Emission</string>
+    <string name="property_key_energy_consumption">Geschätzter Verbrauch (GPS-basiert)</string>
+    <string name="property_key_energy_co2_emission">Geschätzte CO\u2082 Emission (GPS-basiert)</string>
     <string name="property_key_throttle_position">Drosselklappenstellung</string>
     <string name="property_key_engine_load">Motorlast</string>
     <string name="property_key_gps_accuracy">GPS Genauigkeit</string>


### PR DESCRIPTION
fixed the issue #831 . This issue only occured in German language, because the menu items for consumption and GPS-based consumtion were named identical. 