### PR TITLE
Fix/scrollBluetoothDevices

### DIFF
--- a/org.envirocar.app/res/layout/activity_obd_selection_fragment.xml
+++ b/org.envirocar.app/res/layout/activity_obd_selection_fragment.xml
@@ -42,7 +42,6 @@
             android:text="@string/obd_selection_paired_devices"
             android:textColor="@color/blue_dark_cario"
             android:textSize="14sp"
-            android:visibility="gone"
             app:layout_constraintTop_toTopOf="parent"
             tools:layout_editor_absoluteX="16dp" />
 
@@ -54,6 +53,17 @@
             app:layout_constraintBottom_toTopOf="@+id/linearLayout"
             app:layout_constraintTop_toBottomOf="@+id/activity_obd_selection_layout_paired_devices_text"
             tools:layout_editor_absoluteX="16dp" />
+
+        <TextView
+            android:id="@+id/activity_obd_selection_layout_paired_devices_info"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_margin="10dp"
+            android:gravity="center"
+            android:text="@string/obd_selection_no_paired_devices"
+            app:layout_constraintBottom_toTopOf="@+id/linearLayout"
+            app:layout_constraintTop_toBottomOf="@+id/activity_obd_selection_layout_paired_devices_text"
+            tools:layout_editor_absoluteX="26dp" />
 
         <LinearLayout
             android:id="@+id/linearLayout"
@@ -101,6 +111,17 @@
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/linearLayout"
             tools:layout_editor_absoluteX="16dp" />
+
+        <TextView
+            android:id="@+id/activity_obd_selection_layout_available_devices_info"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_margin="10dp"
+            android:gravity="center"
+            android:text="@string/obd_selection_no_available_devices"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/linearLayout"
+            tools:layout_editor_absoluteX="26dp" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/org.envirocar.app/res/values-de/strings_obd_selection.xml
+++ b/org.envirocar.app/res/values-de/strings_obd_selection.xml
@@ -29,12 +29,15 @@
     <string name="obd_selection_discovery_started">Suche gestartet!</string>
     <string name="obd_selection_is_selected_template">%s ausgewählt.</string>
 
-    <string name="obd_selection_paired_devices">Gepaarte Geräte</string>
+    <string name="obd_selection_no_paired_devices">Keine gekoppelten Bluetooth-Geräte.</string>
+    <string name="obd_selection_no_available_devices">Keine Bluetooth-Geräte gefunden.</string>
+
+    <string name="obd_selection_paired_devices">Gekoppelte Geräte</string>
     <string name="obd_selection_avaiable_devices">Verfügbare Geräte</string>
 
-    <string name="obd_selection_dialog_pairing_title">Mit Gerät koppeln</string>
+    <string name="obd_selection_dialog_pairing_title">Gerät koppeln</string>
     <string name="obd_selection_dialog_pairing_content_template">Möchten Sie ihr Gerät mit %s koppeln?</string>
-    <string name="obd_selection_dialog_delete_pairing_title">Paarung löschen?</string>
+    <string name="obd_selection_dialog_delete_pairing_title">Gerät entkoppeln?</string>
     <string name="obd_selection_dialog_delete_pairing_content_template">Möchten Sie die Kopplung mit \"%s\" löschen?</string>
 
     <string name="obd_selection_device_unpaired_template">%s wurde entkoppelt.</string>

--- a/org.envirocar.app/res/values/strings_obd_selection.xml
+++ b/org.envirocar.app/res/values/strings_obd_selection.xml
@@ -29,12 +29,15 @@
     <string name="obd_selection_discovery_started">Bluetooth discovery started.</string>
     <string name="obd_selection_is_selected_template">%s selected.</string>
 
+    <string name="obd_selection_no_paired_devices">No paired Bluetooth devices</string>
+    <string name="obd_selection_no_available_devices">No Bluetooth devices found</string>
+
     <string name="obd_selection_paired_devices">Paired Devices</string>
-    <string name="obd_selection_avaiable_devices">Available</string>
+    <string name="obd_selection_avaiable_devices">Available Devices</string>
 
     <string name="obd_selection_dialog_pairing_title">Pair Device</string>
     <string name="obd_selection_dialog_pairing_content_template">Do you want to pair with %s?</string>
-    <string name="obd_selection_dialog_delete_pairing_title">Delete Pairing?</string>
+    <string name="obd_selection_dialog_delete_pairing_title">Unpair device?</string>
     <string name="obd_selection_dialog_delete_pairing_content_template">Do you want to remove the pairing with "%s"?</string>
 
     <string name="obd_selection_device_unpaired_template">%s has been unpaired.</string>

--- a/org.envirocar.app/src/org/envirocar/app/views/obdselection/OBDSelectionFragment.java
+++ b/org.envirocar.app/src/org/envirocar/app/views/obdselection/OBDSelectionFragment.java
@@ -108,8 +108,10 @@ public class OBDSelectionFragment extends BaseInjectorFragment implements EasyPe
     @BindView(R.id.activity_obd_selection_layout_rescan_bluetooth)
     protected ImageView mRescanImageView;
 
-//    @BindView(R.id.activity_obd_selection_layout_available_devices_info)
-//    protected TextView mNewDevicesInfoTextView;
+    @BindView(R.id.activity_obd_selection_layout_paired_devices_info)
+    protected TextView mPairedDevicesInfoTextView;
+    @BindView(R.id.activity_obd_selection_layout_available_devices_info)
+    protected TextView mNewDevicesInfoTextView;
 
     // ArrayAdapter for the two different list views.
     private OBDDeviceListAdapter mNewDevicesArrayAdapter;
@@ -345,6 +347,9 @@ public class OBDSelectionFragment extends BaseInjectorFragment implements EasyPe
                         mProgressBar.setVisibility(View.GONE);
                         mRescanImageView.setVisibility(View.VISIBLE);
                         showSnackbar("Discovery Finished!");
+                        if(mNewDevicesArrayAdapter.isEmpty()){
+                            mNewDevicesInfoTextView.setVisibility(View.VISIBLE);
+                        }
 
                     }
 
@@ -363,6 +368,7 @@ public class OBDSelectionFragment extends BaseInjectorFragment implements EasyPe
                         // add it to the list and add an entry to the array adapter.
                         if (!mPairedDevicesAdapter.contains(device) &&
                                 !mNewDevicesArrayAdapter.contains(device)) {
+                            mNewDevicesInfoTextView.setVisibility(View.GONE);
                             mNewDevicesArrayAdapter.add(device);
                         }
                     }
@@ -446,7 +452,8 @@ public class OBDSelectionFragment extends BaseInjectorFragment implements EasyPe
                                 device.getName() + " (" + device.getAddress() + ")"));
                         mPairedDevicesAdapter.remove(device);
                         if (mPairedDevicesAdapter.getCount() == 0 ){
-                            mPairedDevicesTextView.setVisibility(View.GONE);
+                            mPairedDevicesInfoTextView.setVisibility(View.VISIBLE);
+                            //mPairedDevicesTextView.setVisibility(View.GONE);
                         }
                         updatePairedDevicesList();
                     }
@@ -474,7 +481,8 @@ public class OBDSelectionFragment extends BaseInjectorFragment implements EasyPe
 
         // Make the paired devices textview visible if there are paired devices
         if (!pairedDevices.isEmpty()) {
-            mPairedDevicesTextView.setVisibility(View.VISIBLE);
+            mPairedDevicesInfoTextView.setVisibility(View.GONE);
+            //mPairedDevicesTextView.setVisibility(View.VISIBLE);
         }
     }
 
@@ -519,7 +527,8 @@ public class OBDSelectionFragment extends BaseInjectorFragment implements EasyPe
                                 device.getName()));
                         mNewDevicesArrayAdapter.remove(device);
                         mPairedDevicesAdapter.add(device);
-                        mPairedDevicesTextView.setVisibility(View.VISIBLE);
+                        mPairedDevicesInfoTextView.setVisibility(View.GONE);
+                        //mPairedDevicesTextView.setVisibility(View.VISIBLE);
 
                         // Post an event to all registered handlers.
                         mBus.post(new BluetoothPairingChangedEvent(device, true));


### PR DESCRIPTION
When many Bluetooth devices are added, the list of paired devices becomes so big the list of available devices is not diplayed. Solve the problem by giving the lists a fixed area in which they are displayed. Also adding a info text which is shown, when the lists are empty.