### PR TITLE
Fix/unstableBluetoothConnectWorkflow

### DIFF
--- a/org.envirocar.app/res/values-de/strings_bluetooth_pairing_preference.xml
+++ b/org.envirocar.app/res/values-de/strings_bluetooth_pairing_preference.xml
@@ -20,12 +20,12 @@
 
 -->
 <resources>
-    <string name="bluetooth_pairing_preference_toolbar_title">Bluetooth Pairing</string>
+    <string name="bluetooth_pairing_preference_toolbar_title">Bluetooth Kopplung</string>
     <string name="select_bluetooth_preference_info_no_device_found">Kein Bluetoothgerät gefunden.</string>
     <string name="bluetooth_pairing_preference_info_searching_devices">Suche nach anderen Bluetoothgeräten...</string>
     <string name="bluetooth_pairing_preference_info_devices_found">%s Bluetooth devices found.</string>
     <string name="bluetooth_pairing_preference_info_device_found">1 Bluetooth device found.</string>
-    <string name="bluetooth_pairing_preference_dialog_remove_pairing">Delete</string>
+    <string name="bluetooth_pairing_preference_dialog_remove_pairing">Löschen</string>
 
     <string name="pref_bt_discovery_interval_title">Set Discovery Interval</string>
     <string name="pref_bt_discovery_interval_explanation">Select the interval (in minutes + seconds) at which the application re-initiates the discovery process.</string>

--- a/org.envirocar.app/res/values-de/strings_obd_selection.xml
+++ b/org.envirocar.app/res/values-de/strings_obd_selection.xml
@@ -27,6 +27,7 @@
     <string name="obd_selection_bluetooth_disabled">Bluetooth ist deaktiviert.</string>
     <string name="obd_selection_bluetooth_disabled_snackbar">Bluetooth ist deaktiviert. Bitte aktivieren Sie Bluetooth, bevor Sie nach anderen Geräten suchen können.</string>
     <string name="obd_selection_discovery_started">Suche gestartet!</string>
+    <string name="obd_selection_discovery_finished">Suche beendet!</string>
     <string name="obd_selection_is_selected_template">%s ausgewählt.</string>
 
     <string name="obd_selection_no_paired_devices">Keine gekoppelten Bluetooth-Geräte.</string>

--- a/org.envirocar.app/res/values/strings_obd_selection.xml
+++ b/org.envirocar.app/res/values/strings_obd_selection.xml
@@ -27,6 +27,7 @@
     <string name="obd_selection_bluetooth_disabled">Bluetooth is disabled.</string>
     <string name="obd_selection_bluetooth_disabled_snackbar">Bluetooth is disabled. Please enable Bluetooth before you can discover other devices.</string>
     <string name="obd_selection_discovery_started">Bluetooth discovery started.</string>
+    <string name="obd_selection_discovery_finished">Bluetooth discovery finished.</string>
     <string name="obd_selection_is_selected_template">%s selected.</string>
 
     <string name="obd_selection_no_paired_devices">No paired Bluetooth devices</string>

--- a/org.envirocar.app/src/org/envirocar/app/views/obdselection/OBDSelectionFragment.java
+++ b/org.envirocar.app/src/org/envirocar/app/views/obdselection/OBDSelectionFragment.java
@@ -116,10 +116,15 @@ public class OBDSelectionFragment extends BaseInjectorFragment implements EasyPe
 
     private Disposable mBTDiscoverySubscription;
 
+    private boolean isResumed = false;
+    public boolean pairingIsRunning = false;
+
     @Nullable
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle
             savedInstanceState) {
+        super.onCreateView(inflater, container, savedInstanceState);
+
         // infalte the content view of this activity.
         View contentView = inflater.inflate(R.layout.activity_obd_selection_fragment,
                 container, false);
@@ -129,9 +134,6 @@ public class OBDSelectionFragment extends BaseInjectorFragment implements EasyPe
 
         // Setup the listviews, its adapters, and its onClick listener.
         setupListViews();
-
-        // Setup the paired devices.
-        updatePairedDevicesList();
 
         // Check the GPS and Location permissions
         // before Starting the discovery of bluetooth devices.
@@ -241,7 +243,8 @@ public class OBDSelectionFragment extends BaseInjectorFragment implements EasyPe
         // Check whether the GPS is turned or not
         if (manager.isProviderEnabled(GPS_PROVIDER)) {
             // if the GPS is also enabled, start discovery
-            startBluetoothDiscovery();
+            if(isResumed)
+                startBluetoothDiscovery();
         } else {
             // Request to turn GPS on
             buildAlertMessageNoGps();
@@ -274,6 +277,7 @@ public class OBDSelectionFragment extends BaseInjectorFragment implements EasyPe
     @Override
     public void onResume() {
         super.onResume();
+        isResumed = true;
         checkGpsAfterDialog();
     }
 
@@ -282,7 +286,7 @@ public class OBDSelectionFragment extends BaseInjectorFragment implements EasyPe
         final LocationManager manager = (LocationManager) this.getContext().getSystemService(Context.LOCATION_SERVICE);
 
         // Check whether the GPS is turned or not
-        if (EasyPermissions.hasPermissions(getContext(), perms) && manager.isProviderEnabled(GPS_PROVIDER)) {
+        if (EasyPermissions.hasPermissions(getContext(), perms) && manager.isProviderEnabled(GPS_PROVIDER) && !pairingIsRunning) {
             startBluetoothDiscovery();
         }
     }
@@ -343,7 +347,7 @@ public class OBDSelectionFragment extends BaseInjectorFragment implements EasyPe
 
                         mProgressBar.setVisibility(View.GONE);
                         mRescanImageView.setVisibility(View.VISIBLE);
-                        showSnackbar("Discovery Finished!");
+                        showSnackbar(getString(R.string.obd_selection_discovery_finished));
                         if(mNewDevicesArrayAdapter.isEmpty()){
                             mNewDevicesInfoTextView.setVisibility(View.VISIBLE);
                         }
@@ -500,6 +504,7 @@ public class OBDSelectionFragment extends BaseInjectorFragment implements EasyPe
 
                     @Override
                     public void onPairingStarted(BluetoothDevice device) {
+                        pairingIsRunning = true;
                         showSnackbar(getString(R.string.obd_selection_pairing_started));
                         if (text != null) {
                             text.setText(device.getName() + " (Pairing started...)");
@@ -508,6 +513,7 @@ public class OBDSelectionFragment extends BaseInjectorFragment implements EasyPe
 
                     @Override
                     public void onPairingError(BluetoothDevice device) {
+                        pairingIsRunning = false;
                         if (getActivity() != null) {
                             Toast.makeText(getActivity(),
                                     R.string.obd_selection_pairing_error,
@@ -519,14 +525,23 @@ public class OBDSelectionFragment extends BaseInjectorFragment implements EasyPe
 
                     @Override
                     public void onDevicePaired(BluetoothDevice device) {
+                        pairingIsRunning = false;
                         // Device is paired. Add it to the array adapter for paired devices and
                         // remove it from the adapter for new devices.
-                        showSnackbar(getString(R.string.obd_selection_pairing_success_template,
+                        showSnackbar(String.format(
+                                getString(R.string.obd_selection_pairing_success_template),
                                 device.getName()));
+                        // TODO Issue: Unstable bluetooth connect workflow #844
+                        //  --> under the in the issue explained circumstances the getString()-methode
+                        //  fails at this point because the fragment has no context
+
                         mNewDevicesArrayAdapter.remove(device);
                         mPairedDevicesAdapter.add(device);
+
                         mPairedDevicesInfoTextView.setVisibility(View.GONE);
-                        //mPairedDevicesTextView.setVisibility(View.VISIBLE);
+                        if (mNewDevicesArrayAdapter.isEmpty()) {
+                            mNewDevicesInfoTextView.setVisibility(View.VISIBLE);
+                        }
 
                         // Post an event to all registered handlers.
                         mBus.post(new BluetoothPairingChangedEvent(device, true));


### PR DESCRIPTION
addressing the issue #844 . I fixed the multiple occurence of the same device in the list. The cause for this was that with every new pairing a new BroadcastReceiver was created. For now, I could not solve the issue which causes the app to crash. I only found out that  on the callback onDevicePaired() the fragment has no context which causes the app-crash.