### PR TITLE
Changed Tint of Icons in Others section

### DIFF
--- a/org.envirocar.app/res/layout/fragment_others.xml
+++ b/org.envirocar.app/res/layout/fragment_others.xml
@@ -62,6 +62,7 @@
                     android:layout_width="40dp"
                     android:layout_height="40dp"
                     android:padding="6dp"
+                    android:tint="@color/blue_dark_cario"
                     android:src="@drawable/others_logbook"
                     />
 
@@ -97,7 +98,7 @@
                     android:layout_height="40dp"
                     android:padding="6dp"
                     android:src="@drawable/others_settings"
-                    android:tint="@android:color/black"
+                    android:tint="@color/blue_dark_cario"
                     />
 
                 <TextView
@@ -131,6 +132,7 @@
                     android:layout_width="40dp"
                     android:layout_height="40dp"
                     android:padding="6dp"
+                    android:tint="@color/blue_dark_cario"
                     android:src="@drawable/others_help" />
 
                 <TextView
@@ -164,6 +166,7 @@
                     android:layout_width="40dp"
                     android:layout_height="40dp"
                     android:padding="6dp"
+                    android:tint="@color/blue_dark_cario"
                     android:src="@drawable/others_bug" />
 
                 <TextView
@@ -197,6 +200,7 @@
                     android:layout_width="40dp"
                     android:layout_height="40dp"
                     android:padding="6dp"
+                    android:tint="@color/blue_dark_cario"
                     android:src="@drawable/others_rateus" />
 
                 <TextView
@@ -230,6 +234,7 @@
                     android:layout_width="40dp"
                     android:layout_height="40dp"
                     android:padding="6dp"
+                    android:tint="@color/blue_dark_cario"
                     android:src="@drawable/others_logout" />
 
                 <TextView


### PR DESCRIPTION
## Fixes: #903.

## Description:
Changed the Tint of Icons present in the Others section of the android app from default black to the primary colour of the application to improve the theme and style of the app and also to make the respective section less intrusive for users.

## Screenshot of current Others section:
<img src="https://user-images.githubusercontent.com/54114888/161428667-849844a5-4e6d-4f02-a69c-6cdf77cafe02.jpeg" width="300">

## Screenshot of themed Others section:
<img src="https://user-images.githubusercontent.com/54114888/161428845-26d3bc0e-3c84-4239-b08d-1f49d29b1769.jpeg" width="300">