### PR TITLE
Resolved app crashing due to null track id generated when user stops the track recording immediately

### DIFF
--- a/org.envirocar.storage/src/main/java/org/envirocar/storage/EnviroCarDBImpl.java
+++ b/org.envirocar.storage/src/main/java/org/envirocar/storage/EnviroCarDBImpl.java
@@ -177,8 +177,10 @@ public class EnviroCarDBImpl implements EnviroCarDB {
 
     @Override
     public void deleteTrack(Track.TrackId trackId) {
-        trackRoomDatabase.getTrackDAONew().deleteTrack(Long.parseLong(trackId.toString()));
-        deleteMeasurementsOfTrack(trackId);
+        if(trackId != null){
+            trackRoomDatabase.getTrackDAONew().deleteTrack(Long.parseLong(trackId.toString()));
+            deleteMeasurementsOfTrack(trackId);
+        }
     }
 
     @Override


### PR DESCRIPTION
## Fixes #908 
The app was crashing because the user was stopping the track before the track id was generated
Thatswhy in org.envirocar.storage/dao/EnvirocarDBImpl there was a null exception coming as we were trying to convert  null track id to string

## Changes done
Added a null check in org.envirocar.storage/dao/EnvirocarDBImpl to prevent the app from crashing

## Testing
https://user-images.githubusercontent.com/85510030/163068801-daded0d2-aa65-4fcb-b072-9bf195b437eb.mov


