### PR TITLE
Upgraded RxJava from version 2 to 3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -74,9 +74,9 @@ ext {
     supportConstraintLayout = 'androidx.constraintlayout:constraintlayout:2.0.1'
 
     androidxPreference = 'androidx.preference:preference:1.1.1'
-    androidRoom = 'androidx.room:room-runtime:2.2.5'
-    androidRoomRxJava = 'androidx.room:room-rxjava2:2.2.5'
-    supportRoom = 'androidx.room:room-compiler:2.2.5'
+    androidRoom = 'androidx.room:room-runtime:2.4.2'
+    androidRoomRxJava = 'androidx.room:room-rxjava3:2.4.2'
+    supportRoom = 'androidx.room:room-compiler:2.4.2'
 
 
     def lifecycle_version = "2.2.0"
@@ -102,11 +102,11 @@ ext {
     retrofit2 = "com.squareup.retrofit2:retrofit:$retrofit_version"
     retrofitGson2 = "com.squareup.retrofit2:converter-gson:$retrofit_version"
     retrofitAdapters2 = "com.squareup.retrofit2:retrofit-adapters:$retrofit_version"
-    retrofitRxJava2 = "com.squareup.retrofit2:adapter-rxjava2:$retrofit_version"
+    retrofitRxJava3 = "com.squareup.retrofit2:adapter-rxjava3:$retrofit_version"
 
     // RxJava dependencies.
-    rxJava = 'io.reactivex.rxjava2:rxjava:2.2.21'
-    rxAndroid = 'io.reactivex.rxjava2:rxandroid:2.1.1'
+    rxJava = 'io.reactivex.rxjava3:rxjava:3.0.0'
+    rxAndroid = 'io.reactivex.rxjava3:rxandroid:3.0.0'
     rxPreferences = 'com.f2prateek.rx.preferences2:rx-preferences:2.0.1'
 
     // RxBindings

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,3 +12,4 @@ sdk.dir=/home/matthes/opt/android/sdk
 org.gradle.jvmargs=-Xmx2048M
 android.useAndroidX=true
 android.enableJetifier=true
+MAPBOX_DOWNLOADS_TOKEN=sk.eyJ1IjoiYWthc2hyYW1qeW90aGkiLCJhIjoiY2wxODc5ZGZlMGFueTNrcnp6Z3Q5aG9zcCJ9.a4WxmdZTsH8h_jzqfcWSqQ

--- a/org.envirocar.algorithm/src/main/java/org/envirocar/algorithm/MeasurementProvider.java
+++ b/org.envirocar.algorithm/src/main/java/org/envirocar/algorithm/MeasurementProvider.java
@@ -22,7 +22,7 @@ import org.envirocar.core.entity.Measurement;
 import org.envirocar.obd.events.PropertyKeyEvent;
 import org.envirocar.obd.events.Timestamped;
 
-import io.reactivex.Observable;
+import io.reactivex.rxjava3.core.Observable;
 
 /**
  * TODO JavaDoc

--- a/org.envirocar.app/src/org/envirocar/app/BaseApplication.java
+++ b/org.envirocar.app/src/org/envirocar/app/BaseApplication.java
@@ -55,6 +55,7 @@ import org.envirocar.storage.EnviroCarVehicleDB;
 import javax.inject.Inject;
 
 import io.reactivex.disposables.CompositeDisposable;
+import io.reactivex.disposables.Disposable;
 
 
 /**
@@ -119,17 +120,17 @@ public class BaseApplication extends Application {
 
         // debug logging setting listener
         this.disposables.add(
-                ApplicationSettings.getDebugLoggingObservable(this)
+                (Disposable) ApplicationSettings.getDebugLoggingObservable(this)
                         .doOnNext(this::setDebugLogging)
                         .doOnError(LOG::error)
-                        .subscribe());
+                        .doOnSubscribe());
 
         // obfuscation setting changed listener
         this.disposables.add(
-                ApplicationSettings.getObfuscationObservable(this)
+                (Disposable) ApplicationSettings.getObfuscationObservable(this)
                         .doOnNext(bool -> LOG.info("Obfuscation enabled: %s", bool.toString()))
                         .doOnError(LOG::error)
-                        .subscribe());
+                        .doOnSubscribe());
 
         // register Intentfilter for logging screen changes
         IntentFilter screenIntentFilter = new IntentFilter();
@@ -147,7 +148,7 @@ public class BaseApplication extends Application {
                             }
                         })
                         .doOnError(LOG::error)
-                        .subscribe());
+                        .doOnSubscribe());
     }
 
     @Override

--- a/org.envirocar.app/src/org/envirocar/app/handler/ApplicationSettings.java
+++ b/org.envirocar.app/src/org/envirocar/app/handler/ApplicationSettings.java
@@ -31,7 +31,7 @@ import com.google.common.base.Preconditions;
 import org.envirocar.app.R;
 import org.envirocar.app.recording.RecordingType;
 
-import io.reactivex.Observable;
+import io.reactivex.rxjava3.core.Observable;
 
 /**
  * TODO JavaDoc

--- a/org.envirocar.app/src/org/envirocar/app/handler/BluetoothHandler.java
+++ b/org.envirocar.app/src/org/envirocar/app/handler/BluetoothHandler.java
@@ -51,11 +51,11 @@ import java.util.concurrent.TimeUnit;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
-import io.reactivex.Observable;
-import io.reactivex.ObservableEmitter;
-import io.reactivex.Scheduler;
-import io.reactivex.observers.DisposableObserver;
-import io.reactivex.schedulers.Schedulers;
+import io.reactivex.rxjava3.core.Observable;
+import io.reactivex.rxjava3.core.ObservableEmitter;
+import io.reactivex.rxjava3.core.Scheduler;
+import io.reactivex.rxjava3.observers.DisposableObserver;
+import io.reactivex.rxjava3.schedulers.Schedulers;
 
 /**
  * @author dewall

--- a/org.envirocar.app/src/org/envirocar/app/handler/InterpolationMeasurementProvider.java
+++ b/org.envirocar.app/src/org/envirocar/app/handler/InterpolationMeasurementProvider.java
@@ -38,7 +38,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import io.reactivex.Observable;
+import io.reactivex.rxjava3.core.Observable;
 
 
 /**

--- a/org.envirocar.app/src/org/envirocar/app/handler/TrackDAOHandler.java
+++ b/org.envirocar.app/src/org/envirocar/app/handler/TrackDAOHandler.java
@@ -37,8 +37,8 @@ import java.util.ArrayList;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
-import io.reactivex.Observable;
-import io.reactivex.schedulers.Schedulers;
+import io.reactivex.rxjava3.core.Observable;
+import io.reactivex.rxjava3.schedulers.Schedulers;
 
 /**
  * TODO JavaDoc

--- a/org.envirocar.app/src/org/envirocar/app/handler/TrackRecordingHandler.java
+++ b/org.envirocar.app/src/org/envirocar/app/handler/TrackRecordingHandler.java
@@ -48,11 +48,11 @@ import java.util.Date;
 
 import javax.inject.Inject;
 
-import io.reactivex.Completable;
-import io.reactivex.Observable;
+import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.core.Observable;
 import io.reactivex.Single;
 import io.reactivex.functions.Function;
-import io.reactivex.schedulers.Schedulers;
+import io.reactivex.rxjava3.schedulers.Schedulers;
 
 
 /**

--- a/org.envirocar.app/src/org/envirocar/app/handler/TrackUploadHandler.java
+++ b/org.envirocar.app/src/org/envirocar/app/handler/TrackUploadHandler.java
@@ -42,12 +42,12 @@ import java.util.List;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
-import io.reactivex.Observable;
+import io.reactivex.rxjava3.core.Observable;
 import io.reactivex.ObservableOperator;
 import io.reactivex.ObservableTransformer;
 import io.reactivex.Observer;
 import io.reactivex.functions.Function;
-import io.reactivex.observers.DisposableObserver;
+import io.reactivex.rxjava3.observers.DisposableObserver;
 
 
 /**

--- a/org.envirocar.app/src/org/envirocar/app/handler/agreement/AgreementManager.java
+++ b/org.envirocar.app/src/org/envirocar/app/handler/agreement/AgreementManager.java
@@ -44,12 +44,12 @@ import java.util.List;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
-import io.reactivex.Observable;
+import io.reactivex.rxjava3.core.Observable;
 import io.reactivex.ObservableSource;
 import io.reactivex.ObservableTransformer;
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.functions.Function;
-import io.reactivex.schedulers.Schedulers;
+import io.reactivex.rxjava3.schedulers.Schedulers;
 
 /**
  * TODO JavaDoc

--- a/org.envirocar.app/src/org/envirocar/app/handler/preferences/CarPreferenceHandler.java
+++ b/org.envirocar.app/src/org/envirocar/app/handler/preferences/CarPreferenceHandler.java
@@ -60,7 +60,7 @@ import java.util.UUID;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
-import io.reactivex.Observable;
+import io.reactivex.rxjava3.core.Observable;
 
 
 /**

--- a/org.envirocar.app/src/org/envirocar/app/handler/preferences/UserPreferenceHandler.java
+++ b/org.envirocar.app/src/org/envirocar/app/handler/preferences/UserPreferenceHandler.java
@@ -40,7 +40,7 @@ import org.envirocar.core.logging.Logger;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
-import io.reactivex.Completable;
+import io.reactivex.rxjava3.core.Completable;
 
 /**
  * TODO JavaDoc

--- a/org.envirocar.app/src/org/envirocar/app/handler/userstatistics/UserStatisticsProcessor.java
+++ b/org.envirocar.app/src/org/envirocar/app/handler/userstatistics/UserStatisticsProcessor.java
@@ -45,7 +45,7 @@ import org.envirocar.core.EnviroCarDB;
 
 import javax.inject.Inject;
 
-import io.reactivex.observers.DisposableObserver;
+import io.reactivex.rxjava3.observers.DisposableObserver;
 
 
 /**

--- a/org.envirocar.app/src/org/envirocar/app/injection/modules/SchedulerModule.java
+++ b/org.envirocar.app/src/org/envirocar/app/injection/modules/SchedulerModule.java
@@ -24,9 +24,9 @@ import org.envirocar.core.injection.InjectUIScheduler;
 
 import dagger.Module;
 import dagger.Provides;
-import io.reactivex.Scheduler;
+import io.reactivex.rxjava3.core.Scheduler;
 import io.reactivex.android.schedulers.AndroidSchedulers;
-import io.reactivex.schedulers.Schedulers;
+import io.reactivex.rxjava3.schedulers.Schedulers;
 
 @Module
 public class SchedulerModule {

--- a/org.envirocar.app/src/org/envirocar/app/interactor/UploadAllTracks.java
+++ b/org.envirocar.app/src/org/envirocar/app/interactor/UploadAllTracks.java
@@ -37,10 +37,10 @@ import java.util.concurrent.atomic.AtomicInteger;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
-import io.reactivex.Observable;
+import io.reactivex.rxjava3.core.Observable;
 import io.reactivex.ObservableOperator;
-import io.reactivex.Scheduler;
-import io.reactivex.observers.DisposableObserver;
+import io.reactivex.rxjava3.core.Scheduler;
+import io.reactivex.rxjava3.observers.DisposableObserver;
 
 /**
  * @author dewall

--- a/org.envirocar.app/src/org/envirocar/app/interactor/UploadTrack.java
+++ b/org.envirocar.app/src/org/envirocar/app/interactor/UploadTrack.java
@@ -29,8 +29,8 @@ import org.envirocar.core.interactor.Interactor;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
-import io.reactivex.Observable;
-import io.reactivex.Scheduler;
+import io.reactivex.rxjava3.core.Observable;
+import io.reactivex.rxjava3.core.Scheduler;
 
 /**
  * @author dewall

--- a/org.envirocar.app/src/org/envirocar/app/interactor/ValidateAcceptedTerms.java
+++ b/org.envirocar.app/src/org/envirocar/app/interactor/ValidateAcceptedTerms.java
@@ -43,10 +43,10 @@ import org.envirocar.core.utils.rx.dialogs.ReactiveTermsOfUseDialog;
 
 import javax.inject.Inject;
 
-import io.reactivex.Observable;
+import io.reactivex.rxjava3.core.Observable;
 import io.reactivex.ObservableSource;
 import io.reactivex.ObservableTransformer;
-import io.reactivex.Scheduler;
+import io.reactivex.rxjava3.core.Scheduler;
 import io.reactivex.functions.Function;
 
 /**

--- a/org.envirocar.app/src/org/envirocar/app/notifications/AutomaticUploadNotificationHandler.java
+++ b/org.envirocar.app/src/org/envirocar/app/notifications/AutomaticUploadNotificationHandler.java
@@ -42,7 +42,7 @@ import org.envirocar.core.logging.Logger;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
-import io.reactivex.disposables.Disposable;
+import io.reactivex.rxjava3.disposables.Disposable;
 
 /**
  * @author dewall

--- a/org.envirocar.app/src/org/envirocar/app/recording/RecordingService.java
+++ b/org.envirocar.app/src/org/envirocar/app/recording/RecordingService.java
@@ -46,7 +46,7 @@ import javax.inject.Inject;
 
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.disposables.CompositeDisposable;
-import io.reactivex.schedulers.Schedulers;
+import io.reactivex.rxjava3.schedulers.Schedulers;
 
 /**
  * @author dewall
@@ -119,7 +119,7 @@ public class RecordingService extends ScopedBaseInjectorService {
                     }
                 })
                 .doOnError(LOG::error)
-                .subscribe());
+                .doOnSubscribe());
     }
 
     @Override

--- a/org.envirocar.app/src/org/envirocar/app/recording/notification/SpeechOutput.java
+++ b/org.envirocar.app/src/org/envirocar/app/recording/notification/SpeechOutput.java
@@ -35,7 +35,7 @@ import org.envirocar.core.logging.Logger;
 
 import java.util.Locale;
 
-import io.reactivex.disposables.Disposable;
+import io.reactivex.rxjava3.disposables.Disposable;
 
 
 /**

--- a/org.envirocar.app/src/org/envirocar/app/recording/provider/LocationProvider.java
+++ b/org.envirocar.app/src/org/envirocar/app/recording/provider/LocationProvider.java
@@ -43,7 +43,7 @@ import java.lang.reflect.Method;
 
 import javax.inject.Inject;
 
-import io.reactivex.Completable;
+import io.reactivex.rxjava3.core.Completable;
 
 /**
  * @author dewall

--- a/org.envirocar.app/src/org/envirocar/app/recording/provider/RecordingDetailsProvider.java
+++ b/org.envirocar.app/src/org/envirocar/app/recording/provider/RecordingDetailsProvider.java
@@ -41,7 +41,7 @@ import org.envirocar.core.entity.Measurement;
 import org.envirocar.core.events.recording.RecordingNewMeasurementEvent;
 import org.envirocar.core.logging.Logger;
 
-import io.reactivex.Scheduler;
+import io.reactivex.rxjava3.core.Scheduler;
 import io.reactivex.android.schedulers.AndroidSchedulers;
 
 

--- a/org.envirocar.app/src/org/envirocar/app/recording/provider/TrackDatabaseSink.java
+++ b/org.envirocar.app/src/org/envirocar/app/recording/provider/TrackDatabaseSink.java
@@ -39,8 +39,8 @@ import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 
-import io.reactivex.Observable;
-import io.reactivex.ObservableOnSubscribe;
+import io.reactivex.rxjava3.core.Observable;
+import io.reactivex.rxjava3.core.ObservableOnSubscribe;
 import io.reactivex.ObservableTransformer;
 
 /**

--- a/org.envirocar.app/src/org/envirocar/app/recording/strategy/GPSRecordingStrategy.java
+++ b/org.envirocar.app/src/org/envirocar/app/recording/strategy/GPSRecordingStrategy.java
@@ -59,17 +59,17 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-import io.reactivex.Observable;
-import io.reactivex.ObservableEmitter;
-import io.reactivex.ObservableOnSubscribe;
+import io.reactivex.rxjava3.core.Observable;
+import io.reactivex.rxjava3.core.ObservableEmitter;
+import io.reactivex.rxjava3.core.ObservableOnSubscribe;
 import io.reactivex.ObservableTransformer;
-import io.reactivex.Scheduler;
+import io.reactivex.rxjava3.core.Scheduler;
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.disposables.CompositeDisposable;
-import io.reactivex.disposables.Disposable;
+import io.reactivex.rxjava3.disposables.Disposable;
 import io.reactivex.functions.Consumer;
-import io.reactivex.observers.DisposableObserver;
-import io.reactivex.schedulers.Schedulers;
+import io.reactivex.rxjava3.observers.DisposableObserver;
+import io.reactivex.rxjava3.schedulers.Schedulers;
 
 /**
  * @author dewall
@@ -192,7 +192,7 @@ public class GPSRecordingStrategy implements LifecycleObserver, RecordingStrateg
         // subscribe for preference changes
         disposables.add(ApplicationSettings.getTrackTrimDurationObservable(context)
                 .doOnNext(newDuration -> this.trackTrimDuration = newDuration)
-                .subscribe());
+                .doOnSubscribe());
     }
 
     @Override

--- a/org.envirocar.app/src/org/envirocar/app/recording/strategy/OBDRecordingStrategy.java
+++ b/org.envirocar.app/src/org/envirocar/app/recording/strategy/OBDRecordingStrategy.java
@@ -61,14 +61,14 @@ import org.envirocar.obd.exception.AllAdaptersFailedException;
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 
-import io.reactivex.Observable;
+import io.reactivex.rxjava3.core.Observable;
 import io.reactivex.ObservableTransformer;
-import io.reactivex.Scheduler;
+import io.reactivex.rxjava3.core.Scheduler;
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.disposables.CompositeDisposable;
-import io.reactivex.disposables.Disposable;
-import io.reactivex.observers.DisposableObserver;
-import io.reactivex.schedulers.Schedulers;
+import io.reactivex.rxjava3.disposables.Disposable;
+import io.reactivex.rxjava3.observers.DisposableObserver;
+import io.reactivex.rxjava3.schedulers.Schedulers;
 
 /**
  * @author dewall
@@ -163,7 +163,7 @@ public class OBDRecordingStrategy implements RecordingStrategy {
         // subscribe for preference changes
         disposables.add(ApplicationSettings.getCampaignProfileObservable(context)
                 .doOnNext(campaign -> this.cycleCommandProfile = getCycleCommandProfile(campaign))
-                .subscribe());
+                .doOnSubscribe());
     }
 
     @Override

--- a/org.envirocar.app/src/org/envirocar/app/recording/strategy/obd/OBDConnectionHandler.java
+++ b/org.envirocar.app/src/org/envirocar/app/recording/strategy/obd/OBDConnectionHandler.java
@@ -38,11 +38,11 @@ import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
-import io.reactivex.Observable;
-import io.reactivex.ObservableEmitter;
-import io.reactivex.ObservableOnSubscribe;
+import io.reactivex.rxjava3.core.Observable;
+import io.reactivex.rxjava3.core.ObservableEmitter;
+import io.reactivex.rxjava3.core.ObservableOnSubscribe;
 import io.reactivex.android.schedulers.AndroidSchedulers;
-import io.reactivex.disposables.Disposable;
+import io.reactivex.rxjava3.disposables.Disposable;
 import io.reactivex.functions.Cancellable;
 
 

--- a/org.envirocar.app/src/org/envirocar/app/rxutils/RxBroadcastReceiver.java
+++ b/org.envirocar.app/src/org/envirocar/app/rxutils/RxBroadcastReceiver.java
@@ -28,10 +28,10 @@ import org.envirocar.core.logging.Logger;
 import java.lang.ref.WeakReference;
 
 import io.reactivex.Emitter;
-import io.reactivex.Observable;
-import io.reactivex.ObservableEmitter;
-import io.reactivex.ObservableOnSubscribe;
-import io.reactivex.disposables.Disposable;
+import io.reactivex.rxjava3.core.Observable;
+import io.reactivex.rxjava3.core.ObservableEmitter;
+import io.reactivex.rxjava3.core.ObservableOnSubscribe;
+import io.reactivex.rxjava3.disposables.Disposable;
 
 /**
  * @author dewall

--- a/org.envirocar.app/src/org/envirocar/app/services/TrackUploadService.java
+++ b/org.envirocar.app/src/org/envirocar/app/services/TrackUploadService.java
@@ -46,12 +46,12 @@ import java.util.List;
 
 import javax.inject.Inject;
 
-import io.reactivex.Observable;
-import io.reactivex.ObservableEmitter;
-import io.reactivex.ObservableOnSubscribe;
+import io.reactivex.rxjava3.core.Observable;
+import io.reactivex.rxjava3.core.ObservableEmitter;
+import io.reactivex.rxjava3.core.ObservableOnSubscribe;
 import io.reactivex.android.schedulers.AndroidSchedulers;
-import io.reactivex.observers.DisposableObserver;
-import io.reactivex.schedulers.Schedulers;
+import io.reactivex.rxjava3.observers.DisposableObserver;
+import io.reactivex.rxjava3.schedulers.Schedulers;
 
 
 /**

--- a/org.envirocar.app/src/org/envirocar/app/services/autoconnect/AutoRecordingService.java
+++ b/org.envirocar.app/src/org/envirocar/app/services/autoconnect/AutoRecordingService.java
@@ -132,7 +132,7 @@ public class AutoRecordingService extends ScopedBaseInjectorService implements A
                             updateAutoRecording();
                         })
                         .doOnError(LOG::error)
-                        .subscribe());
+                        .doOnSubscribe());
     }
 
     @Override

--- a/org.envirocar.app/src/org/envirocar/app/services/autoconnect/GPSAutoRecordingStrategy.java
+++ b/org.envirocar.app/src/org/envirocar/app/services/autoconnect/GPSAutoRecordingStrategy.java
@@ -95,7 +95,7 @@ public class GPSAutoRecordingStrategy implements AutoRecordingStrategy {
                 RxBroadcastReceiver.create(service, new IntentFilter(TRANSITIONS_RECEIVER_ACTION))
                         .doOnNext(this::onReceiveTransitionIntent)
                         .doOnError(LOG::error)
-                        .subscribe());
+                        .doOnSubscribe());
     }
 
     @Override

--- a/org.envirocar.app/src/org/envirocar/app/services/autoconnect/OBDAutoRecordingStrategy.java
+++ b/org.envirocar.app/src/org/envirocar/app/services/autoconnect/OBDAutoRecordingStrategy.java
@@ -44,12 +44,12 @@ import java.io.IOException;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
-import io.reactivex.Observable;
-import io.reactivex.Scheduler;
+import io.reactivex.rxjava3.core.Observable;
+import io.reactivex.rxjava3.core.Scheduler;
 import io.reactivex.disposables.CompositeDisposable;
-import io.reactivex.disposables.Disposable;
+import io.reactivex.rxjava3.disposables.Disposable;
 import io.reactivex.exceptions.Exceptions;
-import io.reactivex.schedulers.Schedulers;
+import io.reactivex.rxjava3.schedulers.Schedulers;
 
 /**
  * @author dewall
@@ -118,7 +118,7 @@ public class OBDAutoRecordingStrategy implements AutoRecordingStrategy {
                     updateDetectionObservable();
                 })
                 .doOnError(LOG::error)
-                .subscribe());
+                .doOnSubscribe());
 
         isCarSelected = carHandler.getCar() != null;
 

--- a/org.envirocar.app/src/org/envirocar/app/views/BaseMainActivity.java
+++ b/org.envirocar.app/src/org/envirocar/app/views/BaseMainActivity.java
@@ -66,10 +66,10 @@ import javax.inject.Inject;
 
 import butterknife.BindView;
 import butterknife.ButterKnife;
-import io.reactivex.Scheduler;
+import io.reactivex.rxjava3.core.Scheduler;
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.disposables.CompositeDisposable;
-import io.reactivex.observers.DisposableObserver;
+import io.reactivex.rxjava3.observers.DisposableObserver;
 
 /**
  * @authro dewall

--- a/org.envirocar.app/src/org/envirocar/app/views/SplashScreenActivity.java
+++ b/org.envirocar.app/src/org/envirocar/app/views/SplashScreenActivity.java
@@ -36,14 +36,14 @@ import java.util.concurrent.TimeUnit;
 import javax.inject.Inject;
 
 import butterknife.ButterKnife;
-import io.reactivex.Completable;
-import io.reactivex.Observable;
+import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.core.Observable;
 import io.reactivex.Single;
 import io.reactivex.android.schedulers.AndroidSchedulers;
-import io.reactivex.disposables.Disposable;
-import io.reactivex.observers.DisposableObserver;
+import io.reactivex.rxjava3.disposables.Disposable;
+import io.reactivex.rxjava3.observers.DisposableObserver;
 import io.reactivex.observers.DisposableSingleObserver;
-import io.reactivex.schedulers.Schedulers;
+import io.reactivex.rxjava3.schedulers.Schedulers;
 
 /**
  * @author dewall

--- a/org.envirocar.app/src/org/envirocar/app/views/carselection/CarSelectionActivity.java
+++ b/org.envirocar.app/src/org/envirocar/app/views/carselection/CarSelectionActivity.java
@@ -58,11 +58,11 @@ import javax.inject.Inject;
 import butterknife.ButterKnife;
 import butterknife.BindView;
 import butterknife.OnClick;
-import io.reactivex.Observable;
+import io.reactivex.rxjava3.core.Observable;
 import io.reactivex.android.schedulers.AndroidSchedulers;
-import io.reactivex.disposables.Disposable;
-import io.reactivex.observers.DisposableObserver;
-import io.reactivex.schedulers.Schedulers;
+import io.reactivex.rxjava3.disposables.Disposable;
+import io.reactivex.rxjava3.observers.DisposableObserver;
+import io.reactivex.rxjava3.schedulers.Schedulers;
 
 /**
  * @author dewall

--- a/org.envirocar.app/src/org/envirocar/app/views/carselection/CarSelectionAddCarFragment.java
+++ b/org.envirocar.app/src/org/envirocar/app/views/carselection/CarSelectionAddCarFragment.java
@@ -53,12 +53,12 @@ import butterknife.BindView;
 import butterknife.ButterKnife;
 import butterknife.OnClick;
 import info.hoang8f.android.segmented.SegmentedGroup;
-import io.reactivex.Observable;
+import io.reactivex.rxjava3.core.Observable;
 import io.reactivex.Single;
 import io.reactivex.android.schedulers.AndroidSchedulers;
-import io.reactivex.observers.DisposableObserver;
+import io.reactivex.rxjava3.observers.DisposableObserver;
 import io.reactivex.observers.DisposableSingleObserver;
-import io.reactivex.schedulers.Schedulers;
+import io.reactivex.rxjava3.schedulers.Schedulers;
 
 public class CarSelectionAddCarFragment extends BaseInjectorFragment {
     private static final Logger LOG = Logger.getLogger(CarSelectionAddCarFragment.class);

--- a/org.envirocar.app/src/org/envirocar/app/views/carselection/CarSelectionAttributesFragment.java
+++ b/org.envirocar.app/src/org/envirocar/app/views/carselection/CarSelectionAttributesFragment.java
@@ -57,14 +57,14 @@ import butterknife.BindView;
 import butterknife.ButterKnife;
 import butterknife.OnClick;
 import butterknife.OnTextChanged;
-import io.reactivex.Observable;
-import io.reactivex.Scheduler;
+import io.reactivex.rxjava3.core.Observable;
+import io.reactivex.rxjava3.core.Scheduler;
 import io.reactivex.Single;
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.disposables.CompositeDisposable;
-import io.reactivex.observers.DisposableObserver;
+import io.reactivex.rxjava3.observers.DisposableObserver;
 import io.reactivex.observers.DisposableSingleObserver;
-import io.reactivex.schedulers.Schedulers;
+import io.reactivex.rxjava3.schedulers.Schedulers;
 
 public class CarSelectionAttributesFragment extends BaseInjectorFragment {
 

--- a/org.envirocar.app/src/org/envirocar/app/views/carselection/CarSelectionHsnTsnFragment.java
+++ b/org.envirocar.app/src/org/envirocar/app/views/carselection/CarSelectionHsnTsnFragment.java
@@ -57,14 +57,14 @@ import butterknife.BindView;
 import butterknife.ButterKnife;
 import butterknife.OnClick;
 import butterknife.OnEditorAction;
-import io.reactivex.Observable;
-import io.reactivex.Scheduler;
+import io.reactivex.rxjava3.core.Observable;
+import io.reactivex.rxjava3.core.Scheduler;
 import io.reactivex.Single;
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.disposables.CompositeDisposable;
-import io.reactivex.observers.DisposableObserver;
+import io.reactivex.rxjava3.observers.DisposableObserver;
 import io.reactivex.observers.DisposableSingleObserver;
-import io.reactivex.schedulers.Schedulers;
+import io.reactivex.rxjava3.schedulers.Schedulers;
 
 public class CarSelectionHsnTsnFragment extends BaseInjectorFragment {
 

--- a/org.envirocar.app/src/org/envirocar/app/views/dashboard/DashboardFragment.java
+++ b/org.envirocar.app/src/org/envirocar/app/views/dashboard/DashboardFragment.java
@@ -113,11 +113,11 @@ import butterknife.ButterKnife;
 import butterknife.OnCheckedChanged;
 import butterknife.OnClick;
 import info.hoang8f.android.segmented.SegmentedGroup;
-import io.reactivex.Observable;
+import io.reactivex.rxjava3.core.Observable;
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.disposables.CompositeDisposable;
 import io.reactivex.observers.DisposableCompletableObserver;
-import io.reactivex.schedulers.Schedulers;
+import io.reactivex.rxjava3.schedulers.Schedulers;
 
 import static android.app.Activity.RESULT_OK;
 

--- a/org.envirocar.app/src/org/envirocar/app/views/logbook/LogbookActivity.java
+++ b/org.envirocar.app/src/org/envirocar/app/views/logbook/LogbookActivity.java
@@ -62,8 +62,8 @@ import butterknife.BindView;
 import butterknife.OnClick;
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.disposables.CompositeDisposable;
-import io.reactivex.observers.DisposableObserver;
-import io.reactivex.schedulers.Schedulers;
+import io.reactivex.rxjava3.observers.DisposableObserver;
+import io.reactivex.rxjava3.schedulers.Schedulers;
 
 /**
  * TODO JavaDoc

--- a/org.envirocar.app/src/org/envirocar/app/views/logbook/LogbookAddFuelingFragment.java
+++ b/org.envirocar.app/src/org/envirocar/app/views/logbook/LogbookAddFuelingFragment.java
@@ -76,8 +76,8 @@ import butterknife.BindView;
 import butterknife.ButterKnife;
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.disposables.CompositeDisposable;
-import io.reactivex.observers.DisposableObserver;
-import io.reactivex.schedulers.Schedulers;
+import io.reactivex.rxjava3.observers.DisposableObserver;
+import io.reactivex.rxjava3.schedulers.Schedulers;
 
 import static com.mapbox.mapboxsdk.Mapbox.getApplicationContext;
 

--- a/org.envirocar.app/src/org/envirocar/app/views/login/SigninActivity.java
+++ b/org.envirocar.app/src/org/envirocar/app/views/login/SigninActivity.java
@@ -54,9 +54,9 @@ import butterknife.ButterKnife;
 import butterknife.OnClick;
 import butterknife.OnEditorAction;
 import io.reactivex.android.schedulers.AndroidSchedulers;
-import io.reactivex.disposables.Disposable;
+import io.reactivex.rxjava3.disposables.Disposable;
 import io.reactivex.observers.DisposableCompletableObserver;
-import io.reactivex.schedulers.Schedulers;
+import io.reactivex.rxjava3.schedulers.Schedulers;
 
 /**
  * TODO JavaDoc

--- a/org.envirocar.app/src/org/envirocar/app/views/login/SignupActivity.java
+++ b/org.envirocar.app/src/org/envirocar/app/views/login/SignupActivity.java
@@ -69,10 +69,10 @@ import javax.inject.Inject;
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import butterknife.OnClick;
-import io.reactivex.Scheduler;
+import io.reactivex.rxjava3.core.Scheduler;
 import io.reactivex.android.schedulers.AndroidSchedulers;
-import io.reactivex.disposables.Disposable;
-import io.reactivex.schedulers.Schedulers;
+import io.reactivex.rxjava3.disposables.Disposable;
+import io.reactivex.rxjava3.schedulers.Schedulers;
 
 /**
  * @author dewall

--- a/org.envirocar.app/src/org/envirocar/app/views/obdselection/OBDSelectionFragment.java
+++ b/org.envirocar.app/src/org/envirocar/app/views/obdselection/OBDSelectionFragment.java
@@ -56,9 +56,9 @@ import butterknife.BindView;
 import butterknife.ButterKnife;
 import butterknife.OnClick;
 import io.reactivex.android.schedulers.AndroidSchedulers;
-import io.reactivex.disposables.Disposable;
-import io.reactivex.observers.DisposableObserver;
-import io.reactivex.schedulers.Schedulers;
+import io.reactivex.rxjava3.disposables.Disposable;
+import io.reactivex.rxjava3.observers.DisposableObserver;
+import io.reactivex.rxjava3.schedulers.Schedulers;
 import pub.devrel.easypermissions.EasyPermissions;
 import pub.devrel.easypermissions.PermissionRequest;
 

--- a/org.envirocar.app/src/org/envirocar/app/views/others/OthersFragment.java
+++ b/org.envirocar.app/src/org/envirocar/app/views/others/OthersFragment.java
@@ -59,10 +59,10 @@ import javax.inject.Inject;
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import butterknife.OnClick;
-import io.reactivex.Scheduler;
+import io.reactivex.rxjava3.core.Scheduler;
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.observers.DisposableCompletableObserver;
-import io.reactivex.schedulers.Schedulers;
+import io.reactivex.rxjava3.schedulers.Schedulers;
 
 /**
  * A simple {@link Fragment} subclass.

--- a/org.envirocar.app/src/org/envirocar/app/views/preferences/BluetoothPairingPreference.java
+++ b/org.envirocar.app/src/org/envirocar/app/views/preferences/BluetoothPairingPreference.java
@@ -54,9 +54,9 @@ import javax.inject.Inject;
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import io.reactivex.android.schedulers.AndroidSchedulers;
-import io.reactivex.disposables.Disposable;
-import io.reactivex.observers.DisposableObserver;
-import io.reactivex.schedulers.Schedulers;
+import io.reactivex.rxjava3.disposables.Disposable;
+import io.reactivex.rxjava3.observers.DisposableObserver;
+import io.reactivex.rxjava3.schedulers.Schedulers;
 
 /**
  * @author dewall

--- a/org.envirocar.app/src/org/envirocar/app/views/recordingscreen/RecordingScreenActivity.java
+++ b/org.envirocar.app/src/org/envirocar/app/views/recordingscreen/RecordingScreenActivity.java
@@ -64,7 +64,7 @@ import javax.inject.Inject;
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import butterknife.OnClick;
-import io.reactivex.Observable;
+import io.reactivex.rxjava3.core.Observable;
 import io.reactivex.android.schedulers.AndroidSchedulers;
 
 /**
@@ -205,7 +205,7 @@ public class RecordingScreenActivity extends BaseInjectorActivity {
                 .subscribeOn(AndroidSchedulers.mainThread())
                 .doOnNext(ignore -> switchViews())
                 .doOnError(LOG::error)
-                .subscribe();
+                .doOnSubscribe();
     }
 
     @OnClick(R.id.activity_recscreen_stopbutton)
@@ -231,7 +231,7 @@ public class RecordingScreenActivity extends BaseInjectorActivity {
                 .subscribeOn(AndroidSchedulers.mainThread())
                 .doOnNext(e -> this.gpsImage.setEnabled(e.mGpsSatelliteFix.isFix()))
                 .doOnError(LOG::error)
-                .subscribe();
+                .doOnSubscribe();
     }
 
     @Subscribe
@@ -246,7 +246,7 @@ public class RecordingScreenActivity extends BaseInjectorActivity {
                         timerText.stop();
                 })
                 .doOnError(LOG::error)
-                .subscribe();
+                .doOnSubscribe();
     }
 
     @Subscribe
@@ -259,7 +259,7 @@ public class RecordingScreenActivity extends BaseInjectorActivity {
                 .subscribeOn(AndroidSchedulers.mainThread())
                 .doOnNext(e -> this.bluetoothImage.setEnabled(e.isBluetoothEnabled))
                 .doOnError(LOG::error)
-                .subscribe();
+                .doOnSubscribe();
     }
 
     @Subscribe
@@ -272,7 +272,7 @@ public class RecordingScreenActivity extends BaseInjectorActivity {
                 .subscribeOn(AndroidSchedulers.mainThread())
                 .doOnNext(e -> this.bluetoothImage.setEnabled(e.mDrivingDetected))
                 .doOnError(LOG::error)
-                .subscribe();
+                .doOnSubscribe();
     }
 
     @Subscribe
@@ -281,7 +281,7 @@ public class RecordingScreenActivity extends BaseInjectorActivity {
                 .subscribeOn(AndroidSchedulers.mainThread())
                 .doOnNext(e -> distanceText.setText(String.format("%s km", DECIMAL_FORMATTER.format(e.mDistanceValue))))
                 .doOnError(LOG::error)
-                .subscribe();
+                .doOnSubscribe();
     }
 
     @Subscribe
@@ -290,7 +290,7 @@ public class RecordingScreenActivity extends BaseInjectorActivity {
                 .subscribeOn(AndroidSchedulers.mainThread())
                 .doOnNext(e -> speedText.setText(String.format("%s km/h", Integer.toString(e.mAvrgSpeed))))
                 .doOnError(LOG::error)
-                .subscribe();
+                .doOnSubscribe();
     }
 
     @Subscribe

--- a/org.envirocar.app/src/org/envirocar/app/views/recordingscreen/TrackMapFragment.java
+++ b/org.envirocar.app/src/org/envirocar/app/views/recordingscreen/TrackMapFragment.java
@@ -72,7 +72,7 @@ import butterknife.BindView;
 import butterknife.ButterKnife;
 import butterknife.OnClick;
 import butterknife.OnTouch;
-import io.reactivex.Scheduler;
+import io.reactivex.rxjava3.core.Scheduler;
 import io.reactivex.android.schedulers.AndroidSchedulers;
 
 /**

--- a/org.envirocar.app/src/org/envirocar/app/views/trackdetails/MapExpandedActivity.java
+++ b/org.envirocar.app/src/org/envirocar/app/views/trackdetails/MapExpandedActivity.java
@@ -67,7 +67,7 @@ import butterknife.BindView;
 import butterknife.ButterKnife;
 import butterknife.OnClick;
 import butterknife.OnTouch;
-import io.reactivex.schedulers.Schedulers;
+import io.reactivex.rxjava3.schedulers.Schedulers;
 
 import static android.view.View.GONE;
 

--- a/org.envirocar.app/src/org/envirocar/app/views/trackdetails/TrackDetailsActivity.java
+++ b/org.envirocar.app/src/org/envirocar/app/views/trackdetails/TrackDetailsActivity.java
@@ -77,7 +77,7 @@ import javax.inject.Inject;
 
 import butterknife.BindView;
 import butterknife.ButterKnife;
-import io.reactivex.schedulers.Schedulers;
+import io.reactivex.rxjava3.schedulers.Schedulers;
 
 
 /**

--- a/org.envirocar.app/src/org/envirocar/app/views/trackdetails/TrackStatisticsActivity.java
+++ b/org.envirocar.app/src/org/envirocar/app/views/trackdetails/TrackStatisticsActivity.java
@@ -48,7 +48,7 @@ import javax.inject.Inject;
 import butterknife.ButterKnife;
 import butterknife.BindView;
 import io.reactivex.android.schedulers.AndroidSchedulers;
-import io.reactivex.schedulers.Schedulers;
+import io.reactivex.rxjava3.schedulers.Schedulers;
 import lecho.lib.hellocharts.formatter.SimpleAxisValueFormatter;
 import lecho.lib.hellocharts.gesture.ZoomType;
 import lecho.lib.hellocharts.listener.DummyVieportChangeListener;

--- a/org.envirocar.app/src/org/envirocar/app/views/tracklist/AbstractTrackListCardAdapter.java
+++ b/org.envirocar.app/src/org/envirocar/app/views/tracklist/AbstractTrackListCardAdapter.java
@@ -52,7 +52,7 @@ import java.util.TimeZone;
 
 import butterknife.BindView;
 import butterknife.ButterKnife;
-import io.reactivex.Scheduler;
+import io.reactivex.rxjava3.core.Scheduler;
 import io.reactivex.android.schedulers.AndroidSchedulers;
 
 /**

--- a/org.envirocar.app/src/org/envirocar/app/views/tracklist/AbstractTrackListCardFragment.java
+++ b/org.envirocar.app/src/org/envirocar/app/views/tracklist/AbstractTrackListCardFragment.java
@@ -68,11 +68,11 @@ import javax.inject.Inject;
 
 import butterknife.BindView;
 import butterknife.ButterKnife;
-import io.reactivex.Observable;
-import io.reactivex.Scheduler;
+import io.reactivex.rxjava3.core.Observable;
+import io.reactivex.rxjava3.core.Scheduler;
 import io.reactivex.android.schedulers.AndroidSchedulers;
-import io.reactivex.observers.DisposableObserver;
-import io.reactivex.schedulers.Schedulers;
+import io.reactivex.rxjava3.observers.DisposableObserver;
+import io.reactivex.rxjava3.schedulers.Schedulers;
 
 /**
  * @author dewall

--- a/org.envirocar.app/src/org/envirocar/app/views/tracklist/TrackListLocalCardFragment.java
+++ b/org.envirocar.app/src/org/envirocar/app/views/tracklist/TrackListLocalCardFragment.java
@@ -56,9 +56,9 @@ import javax.inject.Inject;
 
 import butterknife.OnClick;
 import io.reactivex.android.schedulers.AndroidSchedulers;
-import io.reactivex.disposables.Disposable;
-import io.reactivex.observers.DisposableObserver;
-import io.reactivex.schedulers.Schedulers;
+import io.reactivex.rxjava3.disposables.Disposable;
+import io.reactivex.rxjava3.observers.DisposableObserver;
+import io.reactivex.rxjava3.schedulers.Schedulers;
 
 
 /**

--- a/org.envirocar.app/src/org/envirocar/app/views/tracklist/TrackListRemoteCardFragment.java
+++ b/org.envirocar.app/src/org/envirocar/app/views/tracklist/TrackListRemoteCardFragment.java
@@ -45,8 +45,8 @@ import java.util.List;
 
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.disposables.CompositeDisposable;
-import io.reactivex.observers.DisposableObserver;
-import io.reactivex.schedulers.Schedulers;
+import io.reactivex.rxjava3.observers.DisposableObserver;
+import io.reactivex.rxjava3.schedulers.Schedulers;
 
 
 /**

--- a/org.envirocar.app/tests/android/java/org/envirocar/app/test/CarDatabaseTest.java
+++ b/org.envirocar.app/tests/android/java/org/envirocar/app/test/CarDatabaseTest.java
@@ -38,7 +38,7 @@ import java.io.InterruptedIOException;
 import java.util.ArrayList;
 import java.util.List;
 
-import io.reactivex.Completable;
+import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.Single;
 import io.reactivex.observers.DisposableCompletableObserver;
 import io.reactivex.observers.DisposableSingleObserver;

--- a/org.envirocar.app/tests/android/java/org/envirocar/app/test/InterpolationMeasurementProviderTest.java
+++ b/org.envirocar.app/tests/android/java/org/envirocar/app/test/InterpolationMeasurementProviderTest.java
@@ -32,7 +32,7 @@ import java.math.RoundingMode;
 import java.util.List;
 
 import io.reactivex.observers.TestObserver;
-import io.reactivex.schedulers.Schedulers;
+import io.reactivex.rxjava3.schedulers.Schedulers;
 
 public class InterpolationMeasurementProviderTest {
 

--- a/org.envirocar.app/tests/android/java/org/envirocar/app/test/dao/TrackDAOTest.java
+++ b/org.envirocar.app/tests/android/java/org/envirocar/app/test/dao/TrackDAOTest.java
@@ -50,12 +50,12 @@ import java.time.format.DateTimeFormatter;
 import java.util.Date;
 import java.util.List;
 
-import io.reactivex.Observable;
+import io.reactivex.rxjava3.core.Observable;
 import io.reactivex.Observer;
 import io.reactivex.android.schedulers.AndroidSchedulers;
-import io.reactivex.disposables.Disposable;
-import io.reactivex.observers.DisposableObserver;
-import io.reactivex.schedulers.Schedulers;
+import io.reactivex.rxjava3.disposables.Disposable;
+import io.reactivex.rxjava3.observers.DisposableObserver;
+import io.reactivex.rxjava3.schedulers.Schedulers;
 
 @RunWith(AndroidJUnit4.class)
 public class TrackDAOTest {

--- a/org.envirocar.core/src/main/java/org/envirocar/core/EnviroCarDB.java
+++ b/org.envirocar.core/src/main/java/org/envirocar/core/EnviroCarDB.java
@@ -26,7 +26,7 @@ import org.envirocar.core.util.TrackMetadata;
 
 import java.util.List;
 
-import io.reactivex.Observable;
+import io.reactivex.rxjava3.core.Observable;
 
 
 /**
@@ -106,6 +106,6 @@ public interface EnviroCarDB {
     void updateTrackMetadata(final Track track, final TrackMetadata trackMetadata) throws
             TrackSerializationException;
 
-    Observable<TrackMetadata> updateTrackMetadataObservable(final Track track, final TrackMetadata trackMetadata) throws
+    io.reactivex.rxjava3.core.Observable updateTrackMetadataObservable(final Track track, final TrackMetadata trackMetadata) throws
             TrackSerializationException;
 }

--- a/org.envirocar.core/src/main/java/org/envirocar/core/UserManager.java
+++ b/org.envirocar.core/src/main/java/org/envirocar/core/UserManager.java
@@ -20,7 +20,7 @@ package org.envirocar.core;
 
 import org.envirocar.core.entity.User;
 
-import io.reactivex.Completable;
+import io.reactivex.rxjava3.core.Completable;
 
 /**
  * TODO JavaDoc

--- a/org.envirocar.core/src/main/java/org/envirocar/core/dao/AnnouncementDAO.java
+++ b/org.envirocar.core/src/main/java/org/envirocar/core/dao/AnnouncementDAO.java
@@ -26,7 +26,7 @@ import org.envirocar.core.exception.NotConnectedException;
 import java.io.IOException;
 import java.util.List;
 
-import io.reactivex.Observable;
+import io.reactivex.rxjava3.core.Observable;
 
 
 /**

--- a/org.envirocar.core/src/main/java/org/envirocar/core/dao/CarDAO.java
+++ b/org.envirocar.core/src/main/java/org/envirocar/core/dao/CarDAO.java
@@ -29,7 +29,8 @@ import org.envirocar.core.exception.UnauthorizedException;
 
 import java.util.List;
 
-import io.reactivex.Observable;
+import io.reactivex.rxjava3.core.Observable;
+
 
 /**p
  * TODO JavaDoc

--- a/org.envirocar.core/src/main/java/org/envirocar/core/dao/FuelingDAO.java
+++ b/org.envirocar.core/src/main/java/org/envirocar/core/dao/FuelingDAO.java
@@ -27,7 +27,8 @@ import org.envirocar.core.exception.UnauthorizedException;
 
 import java.util.List;
 
-import io.reactivex.Observable;
+import io.reactivex.rxjava3.core.Observable;
+
 
 /**
  * TODO JavaDoc

--- a/org.envirocar.core/src/main/java/org/envirocar/core/dao/TrackDAO.java
+++ b/org.envirocar.core/src/main/java/org/envirocar/core/dao/TrackDAO.java
@@ -28,7 +28,8 @@ import org.envirocar.core.exception.UnauthorizedException;
 
 import java.util.List;
 
-import io.reactivex.Observable;
+import io.reactivex.rxjava3.core.Observable;
+
 
 /**
  * TODO JavaDoc

--- a/org.envirocar.core/src/main/java/org/envirocar/core/dao/UserDAO.java
+++ b/org.envirocar.core/src/main/java/org/envirocar/core/dao/UserDAO.java
@@ -26,7 +26,8 @@ import org.envirocar.core.exception.NotConnectedException;
 import org.envirocar.core.exception.ResourceConflictException;
 import org.envirocar.core.exception.UnauthorizedException;
 
-import io.reactivex.Observable;
+import io.reactivex.rxjava3.core.Observable;
+
 
 /**
  * TODO JavaDoc

--- a/org.envirocar.core/src/main/java/org/envirocar/core/dao/UserStatisticsDAO.java
+++ b/org.envirocar.core/src/main/java/org/envirocar/core/dao/UserStatisticsDAO.java
@@ -23,7 +23,8 @@ import org.envirocar.core.entity.UserStatistics;
 import org.envirocar.core.exception.DataRetrievalFailureException;
 import org.envirocar.core.exception.UnauthorizedException;
 
-import io.reactivex.Observable;
+import io.reactivex.rxjava3.core.Observable;
+
 
 
 /**

--- a/org.envirocar.core/src/main/java/org/envirocar/core/entity/MeasurementTable.java
+++ b/org.envirocar.core/src/main/java/org/envirocar/core/entity/MeasurementTable.java
@@ -35,7 +35,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import io.reactivex.functions.Function;
+
+import io.reactivex.rxjava3.functions.Function;
 
 @Entity(tableName = "measurements")
 public class MeasurementTable {

--- a/org.envirocar.core/src/main/java/org/envirocar/core/entity/TrackTable.java
+++ b/org.envirocar.core/src/main/java/org/envirocar/core/entity/TrackTable.java
@@ -33,7 +33,7 @@ import org.json.JSONException;
 import java.util.ArrayList;
 import java.util.List;
 
-import io.reactivex.functions.Function;
+import io.reactivex.rxjava3.functions.Function;
 
 @Entity(tableName = "tracks")
 public class TrackTable {

--- a/org.envirocar.core/src/main/java/org/envirocar/core/interactor/GetAggregatedUserStatistic.java
+++ b/org.envirocar.core/src/main/java/org/envirocar/core/interactor/GetAggregatedUserStatistic.java
@@ -31,8 +31,12 @@ import org.envirocar.core.repository.UserStatisticRepository;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
-import io.reactivex.Observable;
-import io.reactivex.Scheduler;
+import io.reactivex.rxjava3.core.Observable;
+
+import io.reactivex.rxjava3.core.Scheduler;
+import io.reactivex.rxjava3.schedulers.Schedulers;
+import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers;
+
 
 @Singleton
 public class GetAggregatedUserStatistic extends Interactor<AggregatedUserStatistic, GetAggregatedUserStatistic.Params> {

--- a/org.envirocar.core/src/main/java/org/envirocar/core/interactor/GetLatestPrivacyStatement.java
+++ b/org.envirocar.core/src/main/java/org/envirocar/core/interactor/GetLatestPrivacyStatement.java
@@ -29,8 +29,8 @@ import java.util.Date;
 
 import javax.inject.Inject;
 
-import io.reactivex.Observable;
-import io.reactivex.Scheduler;
+import io.reactivex.rxjava3.core.Observable;
+import io.reactivex.rxjava3.core.Scheduler;
 
 /**
  * @author dewall

--- a/org.envirocar.core/src/main/java/org/envirocar/core/interactor/GetLatestTermsOfUse.java
+++ b/org.envirocar.core/src/main/java/org/envirocar/core/interactor/GetLatestTermsOfUse.java
@@ -28,8 +28,8 @@ import java.util.Date;
 
 import javax.inject.Inject;
 
-import io.reactivex.Observable;
-import io.reactivex.Scheduler;
+import io.reactivex.rxjava3.core.Observable;
+import io.reactivex.rxjava3.core.Scheduler;
 
 /**
  * @author dewall

--- a/org.envirocar.core/src/main/java/org/envirocar/core/interactor/GetUserStatistic.java
+++ b/org.envirocar.core/src/main/java/org/envirocar/core/interactor/GetUserStatistic.java
@@ -28,8 +28,8 @@ import org.envirocar.core.repository.UserStatisticRepository;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
-import io.reactivex.Observable;
-import io.reactivex.Scheduler;
+import io.reactivex.rxjava3.core.Observable;
+import io.reactivex.rxjava3.core.Scheduler;
 
 /**
  * @author dewall

--- a/org.envirocar.core/src/main/java/org/envirocar/core/interactor/Interactor.java
+++ b/org.envirocar.core/src/main/java/org/envirocar/core/interactor/Interactor.java
@@ -20,10 +20,10 @@ package org.envirocar.core.interactor;
 
 import com.google.common.base.Preconditions;
 
-import io.reactivex.Observable;
-import io.reactivex.Scheduler;
-import io.reactivex.disposables.CompositeDisposable;
-import io.reactivex.observers.DisposableObserver;
+import io.reactivex.rxjava3.core.Observable;
+import io.reactivex.rxjava3.core.Scheduler;
+import io.reactivex.rxjava3.disposables.CompositeDisposable;
+import io.reactivex.rxjava3.observers.DisposableObserver;
 
 /**
  * @author dewall

--- a/org.envirocar.core/src/main/java/org/envirocar/core/repository/PrivacyStatementRepository.java
+++ b/org.envirocar.core/src/main/java/org/envirocar/core/repository/PrivacyStatementRepository.java
@@ -24,7 +24,7 @@ import org.envirocar.core.exception.NotConnectedException;
 
 import java.util.List;
 
-import io.reactivex.Observable;
+import io.reactivex.rxjava3.core.Observable;
 
 
 /**

--- a/org.envirocar.core/src/main/java/org/envirocar/core/repository/TermsOfUseRepository.java
+++ b/org.envirocar.core/src/main/java/org/envirocar/core/repository/TermsOfUseRepository.java
@@ -25,7 +25,7 @@ import org.envirocar.core.exception.NotConnectedException;
 
 import java.util.List;
 
-import io.reactivex.Observable;
+import io.reactivex.rxjava3.core.Observable;
 
 /**
  * TODO JavaDoc

--- a/org.envirocar.core/src/main/java/org/envirocar/core/repository/UserStatisticRepository.java
+++ b/org.envirocar.core/src/main/java/org/envirocar/core/repository/UserStatisticRepository.java
@@ -21,7 +21,8 @@ package org.envirocar.core.repository;
 import org.envirocar.core.entity.User;
 import org.envirocar.core.entity.UserStatistic;
 
-import io.reactivex.Observable;
+import io.reactivex.rxjava3.core.Observable;
+
 
 /**
  * @author dewall

--- a/org.envirocar.core/src/main/java/org/envirocar/core/utils/PermissionUtils.java
+++ b/org.envirocar.core/src/main/java/org/envirocar/core/utils/PermissionUtils.java
@@ -25,8 +25,8 @@ import android.content.pm.PackageManager;
 
 import androidx.core.app.ActivityCompat;
 
-import io.reactivex.Completable;
-import io.reactivex.functions.Function;
+import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.functions.Function;
 
 /**
  * @author dewall

--- a/org.envirocar.core/src/main/java/org/envirocar/core/utils/rx/dialogs/AbstractReactiveAcceptDialog.java
+++ b/org.envirocar.core/src/main/java/org/envirocar/core/utils/rx/dialogs/AbstractReactiveAcceptDialog.java
@@ -27,13 +27,13 @@ import org.envirocar.core.entity.BaseEntity;
 import org.envirocar.core.entity.User;
 import org.envirocar.core.logging.Logger;
 
-import io.reactivex.Observable;
-import io.reactivex.ObservableEmitter;
-import io.reactivex.ObservableOnSubscribe;
-import io.reactivex.Scheduler;
-import io.reactivex.android.schedulers.AndroidSchedulers;
-import io.reactivex.disposables.Disposable;
-import io.reactivex.schedulers.Schedulers;
+import io.reactivex.rxjava3.core.Observable;
+import io.reactivex.rxjava3.core.ObservableEmitter;
+import io.reactivex.rxjava3.core.ObservableOnSubscribe;
+import io.reactivex.rxjava3.core.Scheduler;
+import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers;
+import io.reactivex.rxjava3.disposables.Disposable;
+import io.reactivex.rxjava3.schedulers.Schedulers;
 
 
 /**

--- a/org.envirocar.core/src/main/java/org/envirocar/core/utils/rx/dialogs/ReactivePrivacyStatementDialog.java
+++ b/org.envirocar.core/src/main/java/org/envirocar/core/utils/rx/dialogs/ReactivePrivacyStatementDialog.java
@@ -26,7 +26,7 @@ import org.envirocar.core.entity.PrivacyStatement;
 import org.envirocar.core.exception.TermsOfUseException;
 import org.envirocar.core.logging.Logger;
 
-import io.reactivex.ObservableEmitter;
+import io.reactivex.rxjava3.core.ObservableEmitter;
 
 /**
  * @author dewall

--- a/org.envirocar.core/src/main/java/org/envirocar/core/utils/rx/dialogs/ReactiveTermsOfUseDialog.java
+++ b/org.envirocar.core/src/main/java/org/envirocar/core/utils/rx/dialogs/ReactiveTermsOfUseDialog.java
@@ -27,7 +27,7 @@ import org.envirocar.core.entity.TermsOfUse;
 import org.envirocar.core.exception.TermsOfUseException;
 import org.envirocar.core.logging.Logger;
 
-import io.reactivex.ObservableEmitter;
+import io.reactivex.rxjava3.core.ObservableEmitter;
 
 /**
  * TODO JavaDoc

--- a/org.envirocar.obd/src/main/java/org/envirocar/obd/OBDController.java
+++ b/org.envirocar.obd/src/main/java/org/envirocar/obd/OBDController.java
@@ -48,10 +48,10 @@ import java.util.ArrayDeque;
 import java.util.Queue;
 import java.util.concurrent.TimeUnit;
 
-import io.reactivex.Scheduler;
-import io.reactivex.disposables.Disposable;
-import io.reactivex.observers.DisposableObserver;
-import io.reactivex.schedulers.Schedulers;
+import io.reactivex.rxjava3.core.Scheduler;
+import io.reactivex.rxjava3.disposables.Disposable;
+import io.reactivex.rxjava3.observers.DisposableObserver;
+import io.reactivex.rxjava3.schedulers.Schedulers;
 
 
 /**

--- a/org.envirocar.obd/src/main/java/org/envirocar/obd/OBDSchedulers.java
+++ b/org.envirocar.obd/src/main/java/org/envirocar/obd/OBDSchedulers.java
@@ -20,8 +20,8 @@ package org.envirocar.obd;
 
 import java.util.concurrent.Executors;
 
-import io.reactivex.Scheduler;
-import io.reactivex.schedulers.Schedulers;
+import io.reactivex.rxjava3.core.Scheduler;
+import io.reactivex.rxjava3.schedulers.Schedulers;
 
 public class OBDSchedulers {
 

--- a/org.envirocar.obd/src/main/java/org/envirocar/obd/adapter/CommandExecutor.java
+++ b/org.envirocar.obd/src/main/java/org/envirocar/obd/adapter/CommandExecutor.java
@@ -31,9 +31,9 @@ import java.io.OutputStream;
 import java.util.HashSet;
 import java.util.Set;
 
-import io.reactivex.Observable;
-import io.reactivex.ObservableEmitter;
-import io.reactivex.ObservableOnSubscribe;
+import io.reactivex.rxjava3.core.Observable;
+import io.reactivex.rxjava3.core.ObservableEmitter;
+import io.reactivex.rxjava3.core.ObservableOnSubscribe;
 
 public class CommandExecutor {
 

--- a/org.envirocar.obd/src/main/java/org/envirocar/obd/adapter/ELM327Adapter.java
+++ b/org.envirocar.obd/src/main/java/org/envirocar/obd/adapter/ELM327Adapter.java
@@ -34,7 +34,7 @@ import java.util.ArrayDeque;
 import java.util.List;
 import java.util.Queue;
 
-import io.reactivex.Observable;
+import io.reactivex.rxjava3.core.Observable;
 
 
 /**

--- a/org.envirocar.obd/src/main/java/org/envirocar/obd/adapter/OBDAdapter.java
+++ b/org.envirocar.obd/src/main/java/org/envirocar/obd/adapter/OBDAdapter.java
@@ -23,7 +23,7 @@ import org.envirocar.obd.commands.response.DataResponse;
 import java.io.InputStream;
 import java.io.OutputStream;
 
-import io.reactivex.Observable;
+import io.reactivex.rxjava3.core.Observable;
 
 
 /**

--- a/org.envirocar.obd/src/main/java/org/envirocar/obd/adapter/SyncAdapter.java
+++ b/org.envirocar.obd/src/main/java/org/envirocar/obd/adapter/SyncAdapter.java
@@ -52,7 +52,7 @@ import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import io.reactivex.Observable;
+import io.reactivex.rxjava3.core.Observable;
 
 
 public abstract class SyncAdapter implements OBDAdapter {

--- a/org.envirocar.obd/src/main/java/org/envirocar/obd/adapter/async/AsyncAdapter.java
+++ b/org.envirocar.obd/src/main/java/org/envirocar/obd/adapter/async/AsyncAdapter.java
@@ -40,9 +40,9 @@ import java.util.Collections;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import io.reactivex.Observable;
-import io.reactivex.ObservableEmitter;
-import io.reactivex.ObservableOnSubscribe;
+import io.reactivex.rxjava3.core.Observable;
+import io.reactivex.rxjava3.core.ObservableEmitter;
+import io.reactivex.rxjava3.core.ObservableOnSubscribe;
 
 
 /**

--- a/org.envirocar.remote/build.gradle
+++ b/org.envirocar.remote/build.gradle
@@ -38,7 +38,7 @@ dependencies {
     api rootProject.ext.retrofit2
     api rootProject.ext.retrofitGson2
     api rootProject.ext.retrofitAdapters2
-    api rootProject.ext.retrofitRxJava2
+    api rootProject.ext.retrofitRxJava3
 
     // third party
     implementation rootProject.ext.apacheCommons

--- a/org.envirocar.remote/src/main/java/org/envirocar/remote/dao/BaseRemoteDAO.java
+++ b/org.envirocar.remote/src/main/java/org/envirocar/remote/dao/BaseRemoteDAO.java
@@ -28,7 +28,7 @@ import org.envirocar.remote.util.EnvirocarServiceUtils;
 
 import java.io.IOException;
 
-import io.reactivex.Observable;
+import io.reactivex.rxjava3.core.Observable;
 import okhttp3.ResponseBody;
 import retrofit2.Call;
 import retrofit2.Response;

--- a/org.envirocar.remote/src/main/java/org/envirocar/remote/dao/CacheAnnouncementsDAO.java
+++ b/org.envirocar.remote/src/main/java/org/envirocar/remote/dao/CacheAnnouncementsDAO.java
@@ -26,7 +26,7 @@ import java.util.List;
 
 import javax.inject.Inject;
 
-import io.reactivex.Observable;
+import io.reactivex.rxjava3.core.Observable;
 
 /**
  * TODO JavaDoc

--- a/org.envirocar.remote/src/main/java/org/envirocar/remote/dao/CacheCarDAO.java
+++ b/org.envirocar.remote/src/main/java/org/envirocar/remote/dao/CacheCarDAO.java
@@ -28,7 +28,7 @@ import java.util.List;
 
 import javax.inject.Inject;
 
-import io.reactivex.Observable;
+import io.reactivex.rxjava3.core.Observable;
 
 
 /**

--- a/org.envirocar.remote/src/main/java/org/envirocar/remote/dao/CacheFuelingDAO.java
+++ b/org.envirocar.remote/src/main/java/org/envirocar/remote/dao/CacheFuelingDAO.java
@@ -35,7 +35,7 @@ import java.util.List;
 
 import javax.inject.Inject;
 
-import io.reactivex.Observable;
+import io.reactivex.rxjava3.core.Observable;
 
 
 /**

--- a/org.envirocar.remote/src/main/java/org/envirocar/remote/dao/CachePrivacyStatementDAO.java
+++ b/org.envirocar.remote/src/main/java/org/envirocar/remote/dao/CachePrivacyStatementDAO.java
@@ -28,7 +28,7 @@ import java.util.List;
 
 import javax.inject.Inject;
 
-import io.reactivex.Observable;
+import io.reactivex.rxjava3.core.Observable;
 
 
 /**

--- a/org.envirocar.remote/src/main/java/org/envirocar/remote/dao/CacheTermsOfUseDAO.java
+++ b/org.envirocar.remote/src/main/java/org/envirocar/remote/dao/CacheTermsOfUseDAO.java
@@ -27,7 +27,7 @@ import java.util.List;
 
 import javax.inject.Inject;
 
-import io.reactivex.Observable;
+import io.reactivex.rxjava3.core.Observable;
 
 
 public class CacheTermsOfUseDAO extends AbstractCacheDAO implements TermsOfUseRepository {

--- a/org.envirocar.remote/src/main/java/org/envirocar/remote/dao/CacheTrackDAO.java
+++ b/org.envirocar.remote/src/main/java/org/envirocar/remote/dao/CacheTrackDAO.java
@@ -28,7 +28,7 @@ import java.util.List;
 
 import javax.inject.Inject;
 
-import io.reactivex.Observable;
+import io.reactivex.rxjava3.core.Observable;
 
 
 /**

--- a/org.envirocar.remote/src/main/java/org/envirocar/remote/dao/CacheUserDAO.java
+++ b/org.envirocar.remote/src/main/java/org/envirocar/remote/dao/CacheUserDAO.java
@@ -28,7 +28,7 @@ import org.envirocar.core.exception.DataUpdateFailureException;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
-import io.reactivex.Observable;
+import io.reactivex.rxjava3.core.Observable;
 
 /**
  * @author dewall

--- a/org.envirocar.remote/src/main/java/org/envirocar/remote/dao/RemoteAnnouncementsDAO.java
+++ b/org.envirocar.remote/src/main/java/org/envirocar/remote/dao/RemoteAnnouncementsDAO.java
@@ -33,7 +33,7 @@ import java.util.List;
 
 import javax.inject.Inject;
 
-import io.reactivex.Observable;
+import io.reactivex.rxjava3.core.Observable;
 import retrofit2.Call;
 import retrofit2.Response;
 

--- a/org.envirocar.remote/src/main/java/org/envirocar/remote/dao/RemoteCarDAO.java
+++ b/org.envirocar.remote/src/main/java/org/envirocar/remote/dao/RemoteCarDAO.java
@@ -37,7 +37,7 @@ import java.util.Map;
 
 import javax.inject.Inject;
 
-import io.reactivex.Observable;
+import io.reactivex.rxjava3.core.Observable;
 import retrofit2.Call;
 import retrofit2.Response;
 

--- a/org.envirocar.remote/src/main/java/org/envirocar/remote/dao/RemoteFuelingDAO.java
+++ b/org.envirocar.remote/src/main/java/org/envirocar/remote/dao/RemoteFuelingDAO.java
@@ -34,7 +34,7 @@ import java.util.List;
 
 import javax.inject.Inject;
 
-import io.reactivex.Observable;
+import io.reactivex.rxjava3.core.Observable;
 import okhttp3.ResponseBody;
 import retrofit2.Response;
 

--- a/org.envirocar.remote/src/main/java/org/envirocar/remote/dao/RemotePrivacyStatementDAO.java
+++ b/org.envirocar.remote/src/main/java/org/envirocar/remote/dao/RemotePrivacyStatementDAO.java
@@ -29,7 +29,7 @@ import java.util.List;
 
 import javax.inject.Inject;
 
-import io.reactivex.Observable;
+import io.reactivex.rxjava3.core.Observable;
 import retrofit2.Call;
 
 /**

--- a/org.envirocar.remote/src/main/java/org/envirocar/remote/dao/RemoteTermsOfUseDAO.java
+++ b/org.envirocar.remote/src/main/java/org/envirocar/remote/dao/RemoteTermsOfUseDAO.java
@@ -30,7 +30,7 @@ import java.util.List;
 
 import javax.inject.Inject;
 
-import io.reactivex.Observable;
+import io.reactivex.rxjava3.core.Observable;
 import retrofit2.Call;
 
 /**

--- a/org.envirocar.remote/src/main/java/org/envirocar/remote/dao/RemoteTrackDAO.java
+++ b/org.envirocar.remote/src/main/java/org/envirocar/remote/dao/RemoteTrackDAO.java
@@ -39,7 +39,7 @@ import java.util.List;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
-import io.reactivex.Observable;
+import io.reactivex.rxjava3.core.Observable;
 import okhttp3.ResponseBody;
 import retrofit2.Call;
 import retrofit2.Response;

--- a/org.envirocar.remote/src/main/java/org/envirocar/remote/dao/RemoteUserDAO.java
+++ b/org.envirocar.remote/src/main/java/org/envirocar/remote/dao/RemoteUserDAO.java
@@ -36,7 +36,7 @@ import java.io.IOException;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
-import io.reactivex.Observable;
+import io.reactivex.rxjava3.core.Observable;
 import okhttp3.ResponseBody;
 import retrofit2.Call;
 import retrofit2.Response;

--- a/org.envirocar.remote/src/main/java/org/envirocar/remote/dao/RemoteUserStatisticsDAO.java
+++ b/org.envirocar.remote/src/main/java/org/envirocar/remote/dao/RemoteUserStatisticsDAO.java
@@ -33,7 +33,7 @@ import java.io.IOException;
 
 import javax.inject.Inject;
 
-import io.reactivex.Observable;
+import io.reactivex.rxjava3.core.Observable;
 import retrofit2.Call;
 import retrofit2.Response;
 

--- a/org.envirocar.remote/src/main/java/org/envirocar/remote/injection/modules/RetrofitModule.java
+++ b/org.envirocar.remote/src/main/java/org/envirocar/remote/injection/modules/RetrofitModule.java
@@ -35,7 +35,7 @@ import dagger.Provides;
 import okhttp3.HttpUrl;
 import okhttp3.OkHttpClient;
 import retrofit2.Retrofit;
-import retrofit2.adapter.rxjava2.RxJava2CallAdapterFactory;
+import retrofit2.adapter.rxjava3.RxJava3CallAdapterFactory;
 import retrofit2.converter.gson.GsonConverterFactory;
 
 /**
@@ -53,7 +53,7 @@ public class RetrofitModule {
                 .client(client)
                 .baseUrl(baseUrl)
                 .addConverterFactory(GsonConverterFactory.create(gson))
-                .addCallAdapterFactory(RxJava2CallAdapterFactory.create())
+                .addCallAdapterFactory(RxJava3CallAdapterFactory.create())
                 .build();
     }
 

--- a/org.envirocar.remote/src/main/java/org/envirocar/remote/repository/RemotePrivacyStatementRepository.java
+++ b/org.envirocar.remote/src/main/java/org/envirocar/remote/repository/RemotePrivacyStatementRepository.java
@@ -30,7 +30,7 @@ import java.util.List;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
-import io.reactivex.Observable;
+import io.reactivex.rxjava3.core.Observable;
 import retrofit2.Call;
 
 /**

--- a/org.envirocar.remote/src/main/java/org/envirocar/remote/repository/RemoteRepository.java
+++ b/org.envirocar.remote/src/main/java/org/envirocar/remote/repository/RemoteRepository.java
@@ -28,7 +28,7 @@ import org.envirocar.remote.util.EnvirocarServiceUtils;
 
 import java.io.IOException;
 
-import io.reactivex.Observable;
+import io.reactivex.rxjava3.core.Observable;
 import okhttp3.ResponseBody;
 import retrofit2.Call;
 import retrofit2.Response;

--- a/org.envirocar.remote/src/main/java/org/envirocar/remote/repository/RemoteTermsOfUseRepository.java
+++ b/org.envirocar.remote/src/main/java/org/envirocar/remote/repository/RemoteTermsOfUseRepository.java
@@ -30,7 +30,7 @@ import java.util.List;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
-import io.reactivex.Observable;
+import io.reactivex.rxjava3.core.Observable;
 import retrofit2.Call;
 
 /**

--- a/org.envirocar.remote/src/main/java/org/envirocar/remote/repository/RemoteUserStatisticRepository.java
+++ b/org.envirocar.remote/src/main/java/org/envirocar/remote/repository/RemoteUserStatisticRepository.java
@@ -26,7 +26,7 @@ import org.envirocar.remote.service.UserService;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
-import io.reactivex.Observable;
+import io.reactivex.rxjava3.core.Observable;
 import retrofit2.Call;
 
 /**

--- a/org.envirocar.remote/src/main/java/org/envirocar/remote/service/AnnouncementsService.java
+++ b/org.envirocar.remote/src/main/java/org/envirocar/remote/service/AnnouncementsService.java
@@ -23,7 +23,7 @@ import org.envirocar.core.entity.Announcement;
 
 import java.util.List;
 
-import io.reactivex.Observable;
+import io.reactivex.rxjava3.core.Observable;
 import retrofit2.Call;
 import retrofit2.http.GET;
 

--- a/org.envirocar.remote/src/main/java/org/envirocar/remote/service/CarService.java
+++ b/org.envirocar.remote/src/main/java/org/envirocar/remote/service/CarService.java
@@ -23,7 +23,7 @@ import org.envirocar.core.entity.Car;
 
 import java.util.List;
 
-import io.reactivex.Observable;
+import io.reactivex.rxjava3.core.Observable;
 import retrofit2.Call;
 import retrofit2.http.Body;
 import retrofit2.http.GET;

--- a/org.envirocar.remote/src/main/java/org/envirocar/remote/service/FuelingService.java
+++ b/org.envirocar.remote/src/main/java/org/envirocar/remote/service/FuelingService.java
@@ -23,7 +23,7 @@ import org.envirocar.core.entity.Fueling;
 
 import java.util.List;
 
-import io.reactivex.Observable;
+import io.reactivex.rxjava3.core.Observable;
 import okhttp3.ResponseBody;
 import retrofit2.Call;
 import retrofit2.http.Body;

--- a/org.envirocar.remote/src/main/java/org/envirocar/remote/service/TrackService.java
+++ b/org.envirocar.remote/src/main/java/org/envirocar/remote/service/TrackService.java
@@ -24,7 +24,7 @@ import org.envirocar.core.entity.Track;
 
 import java.util.List;
 
-import io.reactivex.Observable;
+import io.reactivex.rxjava3.core.Observable;
 import okhttp3.ResponseBody;
 import retrofit2.Call;
 import retrofit2.http.Body;

--- a/org.envirocar.remote/src/main/java/org/envirocar/remote/service/UserService.java
+++ b/org.envirocar.remote/src/main/java/org/envirocar/remote/service/UserService.java
@@ -24,7 +24,7 @@ import org.envirocar.core.entity.UserStatistic;
 import org.envirocar.core.entity.UserStatistics;
 import org.envirocar.remote.requests.CreateUserRequest;
 
-import io.reactivex.Observable;
+import io.reactivex.rxjava3.core.Observable;
 import okhttp3.ResponseBody;
 import retrofit2.Call;
 import retrofit2.http.Body;

--- a/org.envirocar.storage/src/main/java/org/envirocar/storage/DatabaseModule.java
+++ b/org.envirocar.storage/src/main/java/org/envirocar/storage/DatabaseModule.java
@@ -47,7 +47,7 @@ import javax.inject.Singleton;
 
 import dagger.Module;
 import dagger.Provides;
-import io.reactivex.schedulers.Schedulers;
+import io.reactivex.rxjava3.schedulers.Schedulers;
 
 /**
  * TODO JavaDoc

--- a/org.envirocar.storage/src/main/java/org/envirocar/storage/EnviroCarDBImpl.java
+++ b/org.envirocar.storage/src/main/java/org/envirocar/storage/EnviroCarDBImpl.java
@@ -38,9 +38,9 @@ import java.util.concurrent.TimeUnit;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
-import io.reactivex.Observable;
-import io.reactivex.ObservableTransformer;
-import io.reactivex.functions.Function;
+import io.reactivex.rxjava3.core.Observable;
+import io.reactivex.rxjava3.core.ObservableTransformer;
+import io.reactivex.rxjava3.functions.Function;
 
 
 @Singleton
@@ -251,7 +251,7 @@ public class EnviroCarDBImpl implements EnviroCarDB {
         }
     }
 
-    public Observable<TrackMetadata> updateTrackMetadataObservable(
+    public Observable updateTrackMetadataObservable(
             final Track track, final TrackMetadata trackMetadata) {
         return Observable.create(emitter -> {
             try {

--- a/org.envirocar.storage/src/main/java/org/envirocar/storage/dao/LocalManufacturersDAO.java
+++ b/org.envirocar.storage/src/main/java/org/envirocar/storage/dao/LocalManufacturersDAO.java
@@ -25,7 +25,8 @@ import org.envirocar.core.entity.Manufacturers;
 
 import java.util.List;
 
-import io.reactivex.Observable;
+import io.reactivex.rxjava3.core.Observable;
+
 import io.reactivex.Single;
 
 

--- a/org.envirocar.storage/src/main/java/org/envirocar/storage/dao/LocalPowerSourcesDAO.java
+++ b/org.envirocar.storage/src/main/java/org/envirocar/storage/dao/LocalPowerSourcesDAO.java
@@ -25,7 +25,8 @@ import org.envirocar.core.entity.PowerSource;
 
 import java.util.List;
 
-import io.reactivex.Single;
+
+import io.reactivex.rxjava3.core.Single;
 
 
 @Dao

--- a/org.envirocar.storage/src/main/java/org/envirocar/storage/dao/LocalTrackDAONew.java
+++ b/org.envirocar.storage/src/main/java/org/envirocar/storage/dao/LocalTrackDAONew.java
@@ -32,7 +32,8 @@ import org.envirocar.core.entity.TrackTable;
 import java.util.List;
 
 import io.reactivex.Flowable;
-import io.reactivex.Observable;
+import io.reactivex.rxjava3.core.Observable;
+
 
 @Dao
 public interface LocalTrackDAONew {

--- a/org.envirocar.storage/src/main/java/org/envirocar/storage/dao/LocalVehicleDAO.java
+++ b/org.envirocar.storage/src/main/java/org/envirocar/storage/dao/LocalVehicleDAO.java
@@ -25,8 +25,8 @@ import org.envirocar.core.entity.Vehicles;
 
 import java.util.List;
 
-import io.reactivex.Observable;
-import io.reactivex.Single;
+import io.reactivex.rxjava3.core.Observable;
+import io.reactivex.rxjava3.core.Single;
 
 @Dao
 public interface LocalVehicleDAO extends BaseLocalCarDAO<Vehicles> {


### PR DESCRIPTION
## Fixes: #918.

## Description:
Updated all the dependencies and usage of RxJava from version 2 to 3 and reactive types (First Revision). 