### PR TITLE
Updated Retrofit2 dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -98,7 +98,7 @@ ext {
     otto = 'com.squareup:otto:1.3.8'
 
     // Retrofit2 dependencies.
-    def retrofit_version = "2.6.1"
+    def retrofit_version = "2.8.1"
     retrofit2 = "com.squareup.retrofit2:retrofit:$retrofit_version"
     retrofitGson2 = "com.squareup.retrofit2:converter-gson:$retrofit_version"
     retrofitAdapters2 = "com.squareup.retrofit2:retrofit-adapters:$retrofit_version"


### PR DESCRIPTION
## Description:
Updated the Retrofit2 dependencies from the outdated version `2.6.1` which was released on July 31st, 2019 to version `2.8.1` which was released on March 25th, 2020 as the latest stable and compatible version for the currently used retrofit libraries.