### PR TITLE
Upgraded outdated Libraries/ Dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -91,14 +91,14 @@ ext {
     sqlBrite = 'com.squareup.sqlbrite3:sqlbrite:3.2.0'
 
     // Dependency injection, view injection, event bus...
-    dagger = 'com.google.dagger:dagger:2.35.1'
-    daggerCompiler = 'com.google.dagger:dagger-compiler:2.35.1'
+    dagger = 'com.google.dagger:dagger:2.43.2'
+    daggerCompiler = 'com.google.dagger:dagger-compiler:2.43.2'
     butterKnife = 'com.jakewharton:butterknife:10.2.3'
     butterknifeCompiler = 'com.jakewharton:butterknife-compiler:10.2.3'
     otto = 'com.squareup:otto:1.3.8'
 
     // Retrofit2 dependencies.
-    def retrofit_version = "2.6.1"
+    def retrofit_version = "2.8.1"
     retrofit2 = "com.squareup.retrofit2:retrofit:$retrofit_version"
     retrofitGson2 = "com.squareup.retrofit2:converter-gson:$retrofit_version"
     retrofitAdapters2 = "com.squareup.retrofit2:retrofit-adapters:$retrofit_version"

--- a/build.gradle
+++ b/build.gradle
@@ -85,7 +85,7 @@ ext {
     supportLifecycleCompiler = "androidx.lifecycle:lifecycle-compiler:$lifecycle_version"
 
     // database dependencies
-    def sqlite_version = "2.1.0"
+    def sqlite_version = "2.2.0"
     supportSqlite = "androidx.sqlite:sqlite:$sqlite_version"
     supportSqliteFramework = "androidx.sqlite:sqlite-framework:$sqlite_version"
     sqlBrite = 'com.squareup.sqlbrite3:sqlbrite:3.2.0'


### PR DESCRIPTION
## Description:
Upgraded the following outdated libraries/ dependencies to their latest stable and compatible version.

- SQLite library from version `2.1.0` to version `2.2.0`.
- Retrofit2 library from version `2.6.1` to version `2.8.1`.
- Dagger dependencies from version `2.35.1` to version `2.43.2`.