### PR TITLE
Replaced SQLBrite with SQLDelight

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -88,7 +88,7 @@ ext {
     def sqlite_version = "2.1.0"
     supportSqlite = "androidx.sqlite:sqlite:$sqlite_version"
     supportSqliteFramework = "androidx.sqlite:sqlite-framework:$sqlite_version"
-    sqlBrite = 'com.squareup.sqlbrite3:sqlbrite:3.2.0'
+    sqlDelight = 'com.squareup.sqldelight:gradle-plugin:1.5.0'
 
     // Dependency injection, view injection, event bus...
     dagger = 'com.google.dagger:dagger:2.35.1'

--- a/org.envirocar.storage/build.gradle
+++ b/org.envirocar.storage/build.gradle
@@ -26,7 +26,7 @@ dependencies {
     // RxJava dependencies
     implementation rootProject.ext.rxJava
     implementation rootProject.ext.rxAndroid
-    api rootProject.ext.sqlBrite // change to implementation when updating
+    api rootProject.ext.sqlDelight // change to implementation when updating
 
     // Testing
     testImplementation rootProject.ext.junit
@@ -35,7 +35,7 @@ dependencies {
     // Database Dependencies
     implementation rootProject.ext.supportSqlite
     implementation rootProject.ext.supportSqliteFramework
-    implementation rootProject.ext.sqlBrite
+    implementation rootProject.ext.sqlDelight
 
     // Modules
     api project(path : ':org.envirocar.core')

--- a/org.envirocar.storage/src/main/java/org/envirocar/storage/DatabaseModule.java
+++ b/org.envirocar.storage/src/main/java/org/envirocar/storage/DatabaseModule.java
@@ -29,8 +29,8 @@ import androidx.sqlite.db.SupportSQLiteDatabase;
 import androidx.sqlite.db.SupportSQLiteOpenHelper;
 import androidx.sqlite.db.framework.*;
 
-import com.squareup.sqlbrite3.BriteDatabase;
-import com.squareup.sqlbrite3.SqlBrite;
+import com.squareup.sqldelight.gradle.SqlDelightDatabase;
+import com.squareup.sqldelight.gradle.SqlDelightPlugin;
 
 import org.envirocar.core.EnviroCarDB;
 import org.envirocar.core.entity.PowerSource;


### PR DESCRIPTION
### Fixes: #947.

## Description:
Replaced the deprecated SQLBrite library (https://github.com/square/sqlbrite) with the same vendor that released the newer, SQLDelight library (https://github.com/square/sqldelight) as mentioned in (https://github.com/square/sqlbrite#deprecated) suitable for replacement. 
Followed the same implementation pattern as SQLBrite and replaced all references and usage with SQLDelight.