### PR TITLE
Changed makeIsDashboardFragmentFalse() to onDashboardFragmentFalse()

### DIFF
--- a/org.envirocar.app/src/org/envirocar/app/BaseApplication.java
+++ b/org.envirocar.app/src/org/envirocar/app/BaseApplication.java
@@ -205,12 +205,16 @@ public class BaseApplication extends Application implements AimyboxProvider {
     @NonNull
     @Override
     public Aimybox getAimybox() {
-        return new BaseAimybox(this, mBus, metadataHandler).getAimybox();
+        BaseAimybox.Companion.setCurrentAimybox(new BaseAimybox(this, mBus, metadataHandler).getAimybox());
+        return BaseAimybox.Companion.getCurrentAimybox();
     }
 
     @NonNull
     @Override
     public AimyboxAssistantViewModel.Factory getViewModelFactory() {
-        return AimyboxAssistantViewModel.Factory.Companion.getInstance(getAimybox());
+        if(BaseAimybox.Companion.getCurrentAimybox() == null){
+            return AimyboxAssistantViewModel.Factory.Companion.getInstance(getAimybox());
+        }
+        return AimyboxAssistantViewModel.Factory.Companion.getInstance(BaseAimybox.Companion.getCurrentAimybox());
     }
 }

--- a/org.envirocar.app/src/org/envirocar/app/views/others/TermsOfUseActivity.java
+++ b/org.envirocar.app/src/org/envirocar/app/views/others/TermsOfUseActivity.java
@@ -133,7 +133,7 @@ public class TermsOfUseActivity extends BaseInjectorActivity {
             });
 
         // set `isDashboardFragment` to false
-        metadataHandler.makeIsDashboardFragmentFalse();
+        metadataHandler.onDashboardFragmentFalse();
     }
 
     private void initAcceptanceWorkflow() {

--- a/org.envirocar.app/src/org/envirocar/app/views/settings/SettingsActivity.java
+++ b/org.envirocar.app/src/org/envirocar/app/views/settings/SettingsActivity.java
@@ -25,6 +25,8 @@ import android.content.pm.PackageManager;
 import android.os.Bundle;
 import android.view.View;
 
+import androidx.activity.result.ActivityResultLauncher;
+import androidx.activity.result.contract.ActivityResultContracts;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
@@ -59,6 +61,8 @@ public class SettingsActivity extends AppCompatActivity {
                 .replace(R.id.activity_settings_content, new SettingsFragment())
                 .commit();
     }
+
+
 
     public static class SettingsFragment extends PreferenceFragmentCompat {
 
@@ -136,34 +140,31 @@ public class SettingsActivity extends AppCompatActivity {
         }
 
         public void requestMicrophonePermission() {
-            String[] perms = new String[]{Manifest.permission.RECORD_AUDIO};
 
             // if microphone permission is not granted, request it
             if (!(requireContext().checkCallingOrSelfPermission(Manifest.permission.RECORD_AUDIO)
                     == PackageManager.PERMISSION_GRANTED)) {
-                requestPermissions(perms, RECORD_AUDIO_PERMISSION_REQ_CODE);
+                requestPermissionLauncher.launch(Manifest.permission.RECORD_AUDIO);
             }
         }
 
-        @Override
-        public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
-            super.onRequestPermissionsResult(requestCode, permissions, grantResults);
-            if (requestCode == RECORD_AUDIO_PERMISSION_REQ_CODE) {
-                if (grantResults.length > 0
-                        && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
+        private ActivityResultLauncher<String> requestPermissionLauncher =
+                registerForActivityResult(new ActivityResultContracts.RequestPermission(), isGranted -> {
+                    if (isGranted) {
+                        // Permission is granted. Continue the action or workflow in your
+                        // app.
+                        Snackbar.make(requireView(), R.string.microphone_permission_granted, Snackbar.LENGTH_LONG).show();
+                    } else {
+                        // Explain to the user that the feature is unavailable because the
+                        // feature requires a permission that the user has denied. At the
+                        // same time, respect the user's decision. Don't link to system
+                        // settings in an effort to convince the user to change their
+                        // decision.
+                        this.enableVoiceCommand.setChecked(false);
 
-                    //If user grants permission then show the snackbar
-                    Snackbar.make(requireView(), R.string.microphone_permission_granted, Snackbar.LENGTH_LONG).show();
-                } else {
-                    //If user denies permission then uncheck the checkbox back
-                    // and show the Snackbar to grant permission
-                    this.enableVoiceCommand.setChecked(false);
-
-                    // action opens app's general settings where user can grant microphone/any permission
-                    showGrantMicrophonePermission(requireView(), requireContext(), getActivity());
-
-                }
-            }
-        }
+                        // action opens app's general settings where user can grant microphone/any permission
+                        showGrantMicrophonePermission(requireView(), requireContext(), getActivity());
+                    }
+                });
     }
 }

--- a/voicecommand/src/main/java/org/envirocar/voicecommand/BaseAimybox.kt
+++ b/voicecommand/src/main/java/org/envirocar/voicecommand/BaseAimybox.kt
@@ -47,7 +47,6 @@ class BaseAimybox (
     bus: Bus,
     metadataHandler: MetadataHandler
 ) {
-
     var aimybox: Aimybox
 
     init {
@@ -59,7 +58,6 @@ class BaseAimybox (
         mBus: Bus,
         metadataHandler: MetadataHandler
     ): Aimybox {
-
         // Accessing model from assets folder
         val assets = PocketsphinxAssets
             .fromApkAssets(
@@ -92,6 +90,7 @@ class BaseAimybox (
     }
 
     companion object {
+        private var currentAimybox: Aimybox? = null;
         private const val ARGUMENTS_KEY = "arguments"
         private val sender = UUID.randomUUID().toString()
         private const val WEBHOOK_URL =
@@ -107,6 +106,14 @@ class BaseAimybox (
 
             viewModel.setInitialPhrase(initialPhrase)
 
+        }
+
+        fun setCurrentAimybox(aimybox: Aimybox) {
+            currentAimybox = aimybox;
+        }
+
+        fun getCurrentAimybox() : Aimybox? {
+            return currentAimybox;
         }
 
         fun findAimyboxProvider(activity: Activity): AimyboxProvider? {


### PR DESCRIPTION
Fixes #979 

The purpose of `makeIsDashboardFragmentFalse()` was to set [isDashboardFragment](https://github.com/devAyushDubey/enviroCar-app/blob/edf19e15c480f84bac6f6183c95fc564aa32b9b9/voicecommand/src/main/java/org/envirocar/voicecommand/handler/MetadataHandler.kt#L33) to `false`, which is fulfilled by the method [onDashboardFragmentFalse()](https://github.com/devAyushDubey/enviroCar-app/blob/edf19e15c480f84bac6f6183c95fc564aa32b9b9/voicecommand/src/main/java/org/envirocar/voicecommand/handler/MetadataHandler.kt#L32) now.

![Screenshot (1015)](https://user-images.githubusercontent.com/33064931/223457943-46b8d706-ce0a-4ff1-9683-4b709be4b9cb.png)


