### PR TITLE
Using the new ActivityResults API for handling runtime permission requests

### DIFF
--- a/org.envirocar.app/src/org/envirocar/app/views/others/TermsOfUseActivity.java
+++ b/org.envirocar.app/src/org/envirocar/app/views/others/TermsOfUseActivity.java
@@ -133,7 +133,7 @@ public class TermsOfUseActivity extends BaseInjectorActivity {
             });
 
         // set `isDashboardFragment` to false
-        metadataHandler.makeIsDashboardFragmentFalse();
+        metadataHandler.onDashboardFragmentFalse();
     }
 
     private void initAcceptanceWorkflow() {

--- a/org.envirocar.app/src/org/envirocar/app/views/settings/SettingsActivity.java
+++ b/org.envirocar.app/src/org/envirocar/app/views/settings/SettingsActivity.java
@@ -25,6 +25,8 @@ import android.content.pm.PackageManager;
 import android.os.Bundle;
 import android.view.View;
 
+import androidx.activity.result.ActivityResultLauncher;
+import androidx.activity.result.contract.ActivityResultContracts;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
@@ -59,6 +61,8 @@ public class SettingsActivity extends AppCompatActivity {
                 .replace(R.id.activity_settings_content, new SettingsFragment())
                 .commit();
     }
+
+
 
     public static class SettingsFragment extends PreferenceFragmentCompat {
 
@@ -136,34 +140,31 @@ public class SettingsActivity extends AppCompatActivity {
         }
 
         public void requestMicrophonePermission() {
-            String[] perms = new String[]{Manifest.permission.RECORD_AUDIO};
 
             // if microphone permission is not granted, request it
             if (!(requireContext().checkCallingOrSelfPermission(Manifest.permission.RECORD_AUDIO)
                     == PackageManager.PERMISSION_GRANTED)) {
-                requestPermissions(perms, RECORD_AUDIO_PERMISSION_REQ_CODE);
+                requestPermissionLauncher.launch(Manifest.permission.RECORD_AUDIO);
             }
         }
 
-        @Override
-        public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
-            super.onRequestPermissionsResult(requestCode, permissions, grantResults);
-            if (requestCode == RECORD_AUDIO_PERMISSION_REQ_CODE) {
-                if (grantResults.length > 0
-                        && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
+        private ActivityResultLauncher<String> requestPermissionLauncher =
+                registerForActivityResult(new ActivityResultContracts.RequestPermission(), isGranted -> {
+                    if (isGranted) {
+                        // Permission is granted. Continue the action or workflow in your
+                        // app.
+                        Snackbar.make(requireView(), R.string.microphone_permission_granted, Snackbar.LENGTH_LONG).show();
+                    } else {
+                        // Explain to the user that the feature is unavailable because the
+                        // feature requires a permission that the user has denied. At the
+                        // same time, respect the user's decision. Don't link to system
+                        // settings in an effort to convince the user to change their
+                        // decision.
+                        this.enableVoiceCommand.setChecked(false);
 
-                    //If user grants permission then show the snackbar
-                    Snackbar.make(requireView(), R.string.microphone_permission_granted, Snackbar.LENGTH_LONG).show();
-                } else {
-                    //If user denies permission then uncheck the checkbox back
-                    // and show the Snackbar to grant permission
-                    this.enableVoiceCommand.setChecked(false);
-
-                    // action opens app's general settings where user can grant microphone/any permission
-                    showGrantMicrophonePermission(requireView(), requireContext(), getActivity());
-
-                }
-            }
-        }
+                        // action opens app's general settings where user can grant microphone/any permission
+                        showGrantMicrophonePermission(requireView(), requireContext(), getActivity());
+                    }
+                });
     }
 }


### PR DESCRIPTION
As mentioned in (mentions #982), the requestPermissions() and onRequestPermissionsResult() APIs are deprecated with androidx fragment version 1.3.0

The new approach is to use [ActivityResults API](https://developer.android.com/training/permissions/requesting) and `RequestPermission` contract for requesting single permission at a time or `RequestMultiplePermissions` contract for requesting multiple permission at a time for handling runtime permission requests.

[This](https://medium.com/@ajinkya.kolkhede1/requesting-runtime-permissions-using-new-activityresult-api-cb6116551f00) article also mentions this quite well.

For the microphone request purpose, we have a single permission request to process so I am using `RequestPermission` contract here.

I see multiple locations where we are using requestPermissions() in the `app` and other parts of the project. This PR is specific to the `feature/voicecommand` project.

I would love to implement this upgrade over the entire project in future. Let me know your thoughts.