### PR TITLE
Fix for speech recognition not working on activity change

### DIFF
--- a/org.envirocar.app/src/org/envirocar/app/BaseApplication.java
+++ b/org.envirocar.app/src/org/envirocar/app/BaseApplication.java
@@ -205,12 +205,16 @@ public class BaseApplication extends Application implements AimyboxProvider {
     @NonNull
     @Override
     public Aimybox getAimybox() {
-        return new BaseAimybox(this, mBus, metadataHandler).getAimybox();
+        BaseAimybox.Companion.setCurrentAimybox(new BaseAimybox(this, mBus, metadataHandler).getAimybox());
+        return BaseAimybox.Companion.getCurrentAimybox();
     }
 
     @NonNull
     @Override
     public AimyboxAssistantViewModel.Factory getViewModelFactory() {
-        return AimyboxAssistantViewModel.Factory.Companion.getInstance(getAimybox());
+        if(BaseAimybox.Companion.getCurrentAimybox() == null){
+            return AimyboxAssistantViewModel.Factory.Companion.getInstance(getAimybox());
+        }
+        return AimyboxAssistantViewModel.Factory.Companion.getInstance(BaseAimybox.Companion.getCurrentAimybox());
     }
 }

--- a/org.envirocar.app/src/org/envirocar/app/views/others/TermsOfUseActivity.java
+++ b/org.envirocar.app/src/org/envirocar/app/views/others/TermsOfUseActivity.java
@@ -133,7 +133,7 @@ public class TermsOfUseActivity extends BaseInjectorActivity {
             });
 
         // set `isDashboardFragment` to false
-        metadataHandler.makeIsDashboardFragmentFalse();
+        metadataHandler.onDashboardFragmentFalse();
     }
 
     private void initAcceptanceWorkflow() {

--- a/org.envirocar.app/src/org/envirocar/app/views/settings/SettingsActivity.java
+++ b/org.envirocar.app/src/org/envirocar/app/views/settings/SettingsActivity.java
@@ -25,6 +25,8 @@ import android.content.pm.PackageManager;
 import android.os.Bundle;
 import android.view.View;
 
+import androidx.activity.result.ActivityResultLauncher;
+import androidx.activity.result.contract.ActivityResultContracts;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
@@ -59,6 +61,8 @@ public class SettingsActivity extends AppCompatActivity {
                 .replace(R.id.activity_settings_content, new SettingsFragment())
                 .commit();
     }
+
+
 
     public static class SettingsFragment extends PreferenceFragmentCompat {
 
@@ -136,34 +140,31 @@ public class SettingsActivity extends AppCompatActivity {
         }
 
         public void requestMicrophonePermission() {
-            String[] perms = new String[]{Manifest.permission.RECORD_AUDIO};
 
             // if microphone permission is not granted, request it
             if (!(requireContext().checkCallingOrSelfPermission(Manifest.permission.RECORD_AUDIO)
                     == PackageManager.PERMISSION_GRANTED)) {
-                requestPermissions(perms, RECORD_AUDIO_PERMISSION_REQ_CODE);
+                requestPermissionLauncher.launch(Manifest.permission.RECORD_AUDIO);
             }
         }
 
-        @Override
-        public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
-            super.onRequestPermissionsResult(requestCode, permissions, grantResults);
-            if (requestCode == RECORD_AUDIO_PERMISSION_REQ_CODE) {
-                if (grantResults.length > 0
-                        && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
+        private ActivityResultLauncher<String> requestPermissionLauncher =
+                registerForActivityResult(new ActivityResultContracts.RequestPermission(), isGranted -> {
+                    if (isGranted) {
+                        // Permission is granted. Continue the action or workflow in your
+                        // app.
+                        Snackbar.make(requireView(), R.string.microphone_permission_granted, Snackbar.LENGTH_LONG).show();
+                    } else {
+                        // Explain to the user that the feature is unavailable because the
+                        // feature requires a permission that the user has denied. At the
+                        // same time, respect the user's decision. Don't link to system
+                        // settings in an effort to convince the user to change their
+                        // decision.
+                        this.enableVoiceCommand.setChecked(false);
 
-                    //If user grants permission then show the snackbar
-                    Snackbar.make(requireView(), R.string.microphone_permission_granted, Snackbar.LENGTH_LONG).show();
-                } else {
-                    //If user denies permission then uncheck the checkbox back
-                    // and show the Snackbar to grant permission
-                    this.enableVoiceCommand.setChecked(false);
-
-                    // action opens app's general settings where user can grant microphone/any permission
-                    showGrantMicrophonePermission(requireView(), requireContext(), getActivity());
-
-                }
-            }
-        }
+                        // action opens app's general settings where user can grant microphone/any permission
+                        showGrantMicrophonePermission(requireView(), requireContext(), getActivity());
+                    }
+                });
     }
 }

--- a/voicecommand/src/main/java/org/envirocar/voicecommand/BaseAimybox.kt
+++ b/voicecommand/src/main/java/org/envirocar/voicecommand/BaseAimybox.kt
@@ -47,7 +47,6 @@ class BaseAimybox (
     bus: Bus,
     metadataHandler: MetadataHandler
 ) {
-
     var aimybox: Aimybox
 
     init {
@@ -59,7 +58,6 @@ class BaseAimybox (
         mBus: Bus,
         metadataHandler: MetadataHandler
     ): Aimybox {
-
         // Accessing model from assets folder
         val assets = PocketsphinxAssets
             .fromApkAssets(
@@ -92,6 +90,7 @@ class BaseAimybox (
     }
 
     companion object {
+        private var currentAimybox: Aimybox? = null;
         private const val ARGUMENTS_KEY = "arguments"
         private val sender = UUID.randomUUID().toString()
         private const val WEBHOOK_URL =
@@ -107,6 +106,14 @@ class BaseAimybox (
 
             viewModel.setInitialPhrase(initialPhrase)
 
+        }
+
+        fun setCurrentAimybox(aimybox: Aimybox) {
+            currentAimybox = aimybox;
+        }
+
+        fun getCurrentAimybox() : Aimybox? {
+            return currentAimybox;
         }
 
         fun findAimyboxProvider(activity: Activity): AimyboxProvider? {


### PR DESCRIPTION
## This potentially solves #986

I dug a little deep and found out that the problem here is multiple instantiations of AimyBox.

The `AimyBox` object is supposed to be instantiated only once during the lifecycle of the application (unless in special cases).

What is happening here is, the [initAimyBoxViewModel()](https://github.com/devAyushDubey/enviroCar-app/blob/7c3da432644e643cd2a9c5fa8d17231923025425/org.envirocar.app/src/org/envirocar/app/views/carselection/CarSelectionActivity.java#L173) which is supposed to set the `viewModel` variable to the current `AimyBoxAssistantViewModel`, ends up creating a new instance of AimyBox every time it is called.

https://user-images.githubusercontent.com/33064931/229193760-7d558567-a227-48fd-ac8a-318adcf0e2f5.mp4

The new instance of `AimyBox` creates new workers and connections to Google TTS and SpeechRecognizer, which causes closes the RezendvousChannel set up by the one of the SpeechRecognizers, as a result two workers running two instances of SpeechRecognizer at the same time, hence no input is detected.

### - Two instances of SpeechRecognizer:
![Screenshot (1023)](https://user-images.githubusercontent.com/33064931/229199047-13f79045-ba56-42bc-9c52-1aae63586a99.png)

## - New instance of AimyBox created on entering CarSelection
![Screenshot (1025)](https://user-images.githubusercontent.com/33064931/229199354-646c6f2f-da47-4270-a04f-710689fffcf8.png)



### It is because once we instantiate AimyBox, we are not storing its instance statically for future reference as AimyBox works on **coroutine scope, it does not get destroyed by activity changes.** 


### Potential Solution:

I implemented a simple logic to store the instance of the AimyBox class to its companion object so that it can be referenced further anywhere down the line.

In [BaseApplication.java](https://github.com/devAyushDubey/enviroCar-app/blob/fix/AimyBoxBug/org.envirocar.app/src/org/envirocar/app/BaseApplication.java#L214)
```kotlin
public Aimybox getAimybox() {
      BaseAimybox.Companion.setCurrentAimybox(new BaseAimybox(this, mBus, metadataHandler).getAimybox());
      return BaseAimybox.Companion.getCurrentAimybox();
}
```

In [BaseAimyBox.kt](https://github.com/devAyushDubey/enviroCar-app/blob/fix/AimyBoxBug/voicecommand/src/main/java/org/envirocar/voicecommand/BaseAimybox.kt)
```kotlin
fun setCurrentAimybox(aimybox: Aimybox) {
            currentAimybox = aimybox;
}

fun getCurrentAimybox() : Aimybox? {
            return currentAimybox;
}
```

A review to this would be great, @cdhiraj40 


https://user-images.githubusercontent.com/33064931/229200903-6bb810be-faab-4c8f-8186-d6e61713de4a.mp4




