### PR TITLE
Migrate to Jetpack View Binding

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -9,11 +9,6 @@
 # header note.
 #Tue Jan 26 12:51:21 CET 2016
 sdk.dir=/home/matthes/opt/android/sdk
+org.gradle.jvmargs=-Xmx2048M
 android.useAndroidX=true
 android.enableJetifier=true
-# TODO: Remove after Butter Knife -> Jetpack View Binding migration.
-android.nonFinalResIds=false
-org.gradle.jvmargs=-Xmx2048M \
---add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
---add-exports=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED \
---add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,7 +5,6 @@ agp = "8.4.0"
 androidSegmented = "1.0.6"
 androidxCore = "1.13.1"
 appcompat = "1.6.1"
-butterknife = "10.2.3"
 cardview = "1.0.0"
 circleimageview = "3.1.0"
 commonsCompress = "1.21"
@@ -71,8 +70,6 @@ androidx-rules = { module = "androidx.test:rules", version.ref = "rules" }
 androidx-runner = { module = "androidx.test:runner", version.ref = "runner" }
 androidx-sqlite = { module = "androidx.sqlite:sqlite", version.ref = "sqlite" }
 androidx-sqlite-framework = { module = "androidx.sqlite:sqlite-framework", version.ref = "sqlite" }
-butterknife = { module = "com.jakewharton:butterknife", version.ref = "butterknife" }
-butterknife-compiler = { module = "com.jakewharton:butterknife-compiler", version.ref = "butterknife" }
 circleimageview = { module = "de.hdodenhof:circleimageview", version.ref = "circleimageview" }
 commons-compress = { module = "org.apache.commons:commons-compress", version.ref = "commonsCompress" }
 core = { module = "com.google.android.play:core", version.ref = "playCore" }

--- a/org.envirocar.app/build.gradle
+++ b/org.envirocar.app/build.gradle
@@ -19,6 +19,7 @@ android {
 
     buildFeatures {
         buildConfig true
+        viewBinding true
     }
 
     signingConfigs {
@@ -109,9 +110,6 @@ dependencies {
 
     implementation libs.dagger
     annotationProcessor libs.dagger.compiler
-
-    implementation libs.butterknife
-    annotationProcessor libs.butterknife.compiler
 
     implementation libs.otto
 

--- a/org.envirocar.app/res/layout/activity_car_selection_layout.xml
+++ b/org.envirocar.app/res/layout/activity_car_selection_layout.xml
@@ -31,7 +31,10 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
-        <include layout="@layout/envirocar_toolbar"></include>
+        <include
+            android:id="@+id/envirocar_toolbar"
+            layout="@layout/envirocar_toolbar"
+            />
 
         <RelativeLayout
             android:layout_width="match_parent"

--- a/org.envirocar.app/res/layout/activity_car_selection_newcar_fragment.xml
+++ b/org.envirocar.app/res/layout/activity_car_selection_newcar_fragment.xml
@@ -26,7 +26,7 @@
     android:background="@color/white"
     android:orientation="vertical">
 
-    <include layout="@layout/envirocar_toolbar" />
+    <include android:id="@+id/envirocar_toolbar" layout="@layout/envirocar_toolbar" />
 
     <RelativeLayout
         android:id="@+id/activity_car_selection_top"

--- a/org.envirocar.app/res/layout/activity_track_details_layout.xml
+++ b/org.envirocar.app/res/layout/activity_track_details_layout.xml
@@ -109,7 +109,9 @@
                         android:text="yea"
                         android:textAppearance="@style/TextAppearance.AppCompat.Body1" />
 
-                    <include layout="@layout/activity_track_details_attributes_header" />
+                    <include
+                        android:id="@+id/activity_track_details_attributes_header"
+                        layout="@layout/activity_track_details_attributes_header" />
 
                     <LinearLayout
                         android:layout_width="match_parent"
@@ -118,7 +120,9 @@
                         android:alpha="0.34"
                         android:background="@color/background_material_dark" />
 
-                    <include layout="@layout/activity_track_details_attributes" />
+                    <include
+                        android:id="@+id/activity_track_details_attributes"
+                        layout="@layout/activity_track_details_attributes" />
 
                 </LinearLayout>
             </androidx.cardview.widget.CardView>
@@ -127,12 +131,12 @@
 
     <com.google.android.material.floatingactionbutton.FloatingActionButton
         android:id="@+id/activity_track_details_fab"
+        style="@style/Widget.enviroCar.Fab"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_margin="16dp"
         android:elevation="8dp"
         android:src="@drawable/ic_timeline_white_24dp"
-        style="@style/Widget.enviroCar.Fab"
         app:layout_anchor="@id/activity_track_details_appbar_layout"
         app:layout_anchorGravity="bottom|right|end" />
 

--- a/org.envirocar.app/res/layout/activity_track_statistics_fragment.xml
+++ b/org.envirocar.app/res/layout/activity_track_statistics_fragment.xml
@@ -19,7 +19,7 @@
     with the enviroCar app. If not, see http://www.gnu.org/licenses/.
 
 -->
-<tools:LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -46,4 +46,4 @@
         android:layout_height="0dp"
         android:layout_weight="1"/>
 
-</tools:LinearLayout>
+</LinearLayout>

--- a/org.envirocar.app/res/layout/fragment_tracklist_cardlayout.xml
+++ b/org.envirocar.app/res/layout/fragment_tracklist_cardlayout.xml
@@ -58,7 +58,9 @@
                     android:textSize="18sp"/>
             </androidx.appcompat.widget.Toolbar>
 
-            <include layout="@layout/fragment_tracklist_cardlayout_content" />
+            <include
+                android:id="@+id/fragment_tracklist_cardlayout_content"
+                layout="@layout/fragment_tracklist_cardlayout_content" />
 
         </LinearLayout>
     </androidx.cardview.widget.CardView>

--- a/org.envirocar.app/res/layout/fragment_tracklist_cardlayout_remote.xml
+++ b/org.envirocar.app/res/layout/fragment_tracklist_cardlayout_remote.xml
@@ -81,6 +81,7 @@
             </RelativeLayout>
 
             <include
+                android:id="@+id/fragment_tracklist_cardlayout_content"
                 layout="@layout/fragment_tracklist_cardlayout_content"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"

--- a/org.envirocar.app/res/layout/send_log_layout_new.xml
+++ b/org.envirocar.app/res/layout/send_log_layout_new.xml
@@ -25,7 +25,7 @@
     android:layout_height="match_parent"
     android:orientation="vertical">
 
-    <include layout="@layout/envirocar_toolbar" />
+    <include android:id="@+id/envirocar_toolbar" layout="@layout/envirocar_toolbar" />
 
     <ScrollView
         android:layout_width="match_parent"

--- a/org.envirocar.app/src/org/envirocar/app/BaseApplication.java
+++ b/org.envirocar.app/src/org/envirocar/app/BaseApplication.java
@@ -24,9 +24,7 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
-import android.content.SharedPreferences;
 import android.os.Build;
-import android.preference.PreferenceManager;
 
 import com.mapbox.mapboxsdk.Mapbox;
 
@@ -50,7 +48,6 @@ import org.envirocar.remote.service.FuelingService;
 import org.envirocar.remote.service.TermsOfUseService;
 import org.envirocar.remote.service.TrackService;
 import org.envirocar.remote.service.UserService;
-import org.envirocar.storage.EnviroCarVehicleDB;
 
 import javax.inject.Inject;
 

--- a/org.envirocar.app/src/org/envirocar/app/handler/BluetoothHandler.java
+++ b/org.envirocar.app/src/org/envirocar/app/handler/BluetoothHandler.java
@@ -18,11 +18,12 @@
  */
 package org.envirocar.app.handler;
 
-import android.annotation.SuppressLint;
+import static android.content.Context.BLUETOOTH_SERVICE;
+
 import android.app.Activity;
-import android.app.ActivityManager;
 import android.bluetooth.BluetoothAdapter;
 import android.bluetooth.BluetoothDevice;
+import android.bluetooth.BluetoothManager;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
@@ -35,19 +36,15 @@ import com.google.common.base.Preconditions;
 import com.squareup.otto.Bus;
 import com.squareup.otto.Produce;
 
-import org.envirocar.app.recording.RecordingService;
 import org.envirocar.app.rxutils.RxBroadcastReceiver;
-import org.envirocar.app.views.others.TroubleshootingFragment;
 import org.envirocar.core.events.bluetooth.BluetoothDeviceDiscoveredEvent;
 import org.envirocar.core.events.bluetooth.BluetoothDeviceSelectedEvent;
 import org.envirocar.core.events.bluetooth.BluetoothStateChangedEvent;
 import org.envirocar.core.injection.InjectApplicationScope;
 import org.envirocar.core.logging.Logger;
-import org.envirocar.core.utils.ServiceUtils;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.util.List;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
@@ -141,7 +138,8 @@ public class BluetoothHandler {
         this.bus = bus;
 
         // Get the default bluetooth adapter.
-        mBluetoothAdapter = BluetoothAdapter.getDefaultAdapter();
+        BluetoothManager bluetoothManager = (BluetoothManager) context.getSystemService(BLUETOOTH_SERVICE);
+        mBluetoothAdapter = bluetoothManager.getAdapter();
 
         // Register ourselves on the eventbus.
         this.bus.register(this);
@@ -149,7 +147,7 @@ public class BluetoothHandler {
         // Register this handler class for Bluetooth State Changed broadcasts.
         IntentFilter filter = new IntentFilter(BluetoothAdapter.ACTION_STATE_CHANGED);
         ContextCompat.registerReceiver(
-                this.context, bluetoothPairingReceiver, filter, ContextCompat.RECEIVER_EXPORTED
+                this.context, mBluetoothStateChangedReceiver, filter, ContextCompat.RECEIVER_EXPORTED
         );
     }
 

--- a/org.envirocar.app/src/org/envirocar/app/views/BaseMainActivity.java
+++ b/org.envirocar.app/src/org/envirocar/app/views/BaseMainActivity.java
@@ -147,6 +147,8 @@ public class BaseMainActivity extends BaseInjectorActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         binding = ActivityBaseMainBottomBarBinding.inflate(getLayoutInflater());
+        setContentView(binding.getRoot());
+
         navigationBottomBar = binding.navigation;
         viewPager = binding.fragmentContainer;
 

--- a/org.envirocar.app/src/org/envirocar/app/views/BaseMainActivity.java
+++ b/org.envirocar.app/src/org/envirocar/app/views/BaseMainActivity.java
@@ -41,6 +41,7 @@ import com.squareup.otto.Subscribe;
 
 import org.envirocar.app.BaseApplicationComponent;
 import org.envirocar.app.R;
+import org.envirocar.app.databinding.ActivityBaseMainBottomBarBinding;
 import org.envirocar.app.events.TrackchunkEndUploadedEvent;
 import org.envirocar.app.handler.ApplicationSettings;
 import org.envirocar.app.handler.BluetoothHandler;
@@ -66,8 +67,6 @@ import java.util.Stack;
 
 import javax.inject.Inject;
 
-import butterknife.BindView;
-import butterknife.ButterKnife;
 import io.reactivex.Scheduler;
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.disposables.CompositeDisposable;
@@ -80,6 +79,8 @@ public class BaseMainActivity extends BaseInjectorActivity {
     private static final Logger LOGGER = Logger.getLogger(BaseMainActivity.class);
 
     private static final String TROUBLESHOOTING_TAG = "TROUBLESHOOTING";
+
+    private ActivityBaseMainBottomBarBinding binding;
 
     private FragmentStatePagerAdapter fragmentStatePagerAdapter;
     private MenuItem prevMenuItem;
@@ -114,10 +115,8 @@ public class BaseMainActivity extends BaseInjectorActivity {
     @Inject
     protected ValidateAcceptedTerms validateTermsOfUse;
 
-    @BindView(R.id.navigation)
     protected BottomNavigationView navigationBottomBar;
 
-    @BindView(R.id.fragmentContainer)
     protected ViewPager viewPager;
 
     private CompositeDisposable subscriptions = new CompositeDisposable();
@@ -127,19 +126,13 @@ public class BaseMainActivity extends BaseInjectorActivity {
     private Scheduler.Worker mMainThreadWorker = AndroidSchedulers.mainThread().createWorker();
 
 
-    private BottomNavigationView.OnNavigationItemSelectedListener mOnNavigationItemSelectedListener
-            = item -> {
-        switch (item.getItemId()) {
-            case R.id.navigation_dashboard:
-                viewPager.setCurrentItem(0);
-                return true;
-            case R.id.navigation_my_tracks:
-                viewPager.setCurrentItem(1);
-                return true;
-            case R.id.navigation_others:
-                viewPager.setCurrentItem(2);
-                return true;
-        }
+    private BottomNavigationView.OnNavigationItemSelectedListener mOnNavigationItemSelectedListener = item -> {
+        if (item.getItemId() == R.id.navigation_dashboard)
+            viewPager.setCurrentItem(0);
+        else if (item.getItemId() == R.id.navigation_my_tracks)
+            viewPager.setCurrentItem(1);
+        else if (item.getItemId() == R.id.navigation_others)
+            viewPager.setCurrentItem(2);
         return false;
     };
 
@@ -152,10 +145,10 @@ public class BaseMainActivity extends BaseInjectorActivity {
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
-//        LOGGER.info("BaseMainActivity : onCreate");
         super.onCreate(savedInstanceState);
-        setContentView(R.layout.activity_base_main_bottom_bar);
-        ButterKnife.bind(this);
+        binding = ActivityBaseMainBottomBarBinding.inflate(getLayoutInflater());
+        navigationBottomBar = binding.navigation;
+        viewPager = binding.fragmentContainer;
 
         navigationBottomBar.setOnNavigationItemSelectedListener(mOnNavigationItemSelectedListener);
         navigationBottomBar.setSelectedItemId(R.id.navigation_dashboard);

--- a/org.envirocar.app/src/org/envirocar/app/views/SplashScreenActivity.java
+++ b/org.envirocar.app/src/org/envirocar/app/views/SplashScreenActivity.java
@@ -18,14 +18,12 @@
  */
 package org.envirocar.app.views;
 
-import android.app.Activity;
 import android.content.Intent;
 import android.os.Bundle;
 
 import org.envirocar.app.BaseApplicationComponent;
 import org.envirocar.app.R;
 import org.envirocar.app.injection.BaseInjectorActivity;
-import org.envirocar.app.views.carselection.CarSelectionAddCarFragment;
 import org.envirocar.core.entity.Manufacturers;
 import org.envirocar.core.logging.Logger;
 import org.envirocar.storage.EnviroCarVehicleDB;
@@ -35,14 +33,11 @@ import java.util.concurrent.TimeUnit;
 
 import javax.inject.Inject;
 
-import butterknife.ButterKnife;
 import io.reactivex.Completable;
 import io.reactivex.Observable;
-import io.reactivex.Single;
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.observers.DisposableObserver;
-import io.reactivex.observers.DisposableSingleObserver;
 import io.reactivex.schedulers.Schedulers;
 
 /**
@@ -93,7 +88,6 @@ public class SplashScreenActivity extends BaseInjectorActivity {
 
         setContentView(R.layout.activity_splashscreen);
         getWindow().setNavigationBarColor(getResources().getColor(R.color.cario_color_primary_dark));
-        ButterKnife.bind(this);
 
         if ((getIntent().getFlags() & Intent.FLAG_ACTIVITY_BROUGHT_TO_FRONT) != 0) {
             finish();

--- a/org.envirocar.app/src/org/envirocar/app/views/carselection/BottomSheetFragment.java
+++ b/org.envirocar.app/src/org/envirocar/app/views/carselection/BottomSheetFragment.java
@@ -18,9 +18,6 @@
  */
 package org.envirocar.app.views.carselection;
 
-import android.annotation.SuppressLint;
-import android.app.Dialog;
-import android.content.Context;
 import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -32,29 +29,20 @@ import androidx.annotation.Nullable;
 
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment;
 
-import org.envirocar.app.R;
+import org.envirocar.app.databinding.CarAttributesDetailBottomsheetBinding;
 import org.envirocar.core.entity.Car;
 import org.envirocar.core.entity.Vehicles;
 
-import butterknife.BindView;
-import butterknife.ButterKnife;
-import butterknife.OnClick;
-
 public class BottomSheetFragment extends BottomSheetDialogFragment {
 
-    @BindView(R.id.activity_car_details_attr_manufacturer_value)
+    private CarAttributesDetailBottomsheetBinding binding;
+
     TextView manufacturer;
-    @BindView(R.id.activity_car_details_attr_car_value)
     TextView model;
-    @BindView(R.id.activity_car_details_attr_year_value)
     TextView year;
-    @BindView(R.id.activity_car_details_attr_fuel_value)
     TextView fuel;
-    @BindView(R.id.activity_car_details_attr_power_value)
     TextView power;
-    @BindView(R.id.activity_car_details_attr_engine_value)
     TextView engine;
-    @BindView(R.id.bottomSheetEngineLayout)
     View engineLayout;
 
     Vehicles vehicle;
@@ -66,8 +54,18 @@ public class BottomSheetFragment extends BottomSheetDialogFragment {
     @Nullable
     @Override
     public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
-        View view = inflater.inflate(R.layout.car_attributes_detail_bottomsheet, container,false);
-        ButterKnife.bind(this, view);
+        binding = CarAttributesDetailBottomsheetBinding.inflate(inflater, container, false);
+
+        manufacturer = binding.activityCarDetailsAttrManufacturerValue;
+        model = binding.activityCarDetailsAttrCarValue;
+        year = binding.activityCarDetailsAttrYearValue;
+        fuel = binding.activityCarDetailsAttrFuelValue;
+        power = binding.activityCarDetailsAttrPowerValue;
+        engine = binding.activityCarDetailsAttrEngineValue;
+        engineLayout = binding.bottomSheetEngineLayout;
+        binding.activityCarDetailsCancel.setOnClickListener(v -> cancelSheet());
+        binding.activityCarDetailsCreate.setOnClickListener(v -> proceed());
+
         manufacturer.setText(vehicle.getManufacturer());
         model.setText(vehicle.getCommerical_name());
         year.setText(vehicle.getAllotment_date());
@@ -79,15 +77,19 @@ public class BottomSheetFragment extends BottomSheetDialogFragment {
         } else {
             engineLayout.setVisibility(View.GONE);
         }
-        return view;
+        return binding.getRoot();
     }
 
-    @OnClick(R.id.activity_car_details_cancel)
+    @Override
+    public void onDestroyView() {
+        super.onDestroyView();
+        binding = null;
+    }
+
     void cancelSheet() {
         dismiss();
     }
 
-    @OnClick(R.id.activity_car_details_create)
     void proceed() {
         ((CarSelectionActivity)getActivity()).registerCar(vehicle);
         dismiss();

--- a/org.envirocar.app/src/org/envirocar/app/views/carselection/CarListFragment.java
+++ b/org.envirocar.app/src/org/envirocar/app/views/carselection/CarListFragment.java
@@ -31,28 +31,25 @@ import androidx.recyclerview.widget.RecyclerView;
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment;
 
 import org.envirocar.app.R;
+import org.envirocar.app.databinding.FragmentCarListBinding;
 import org.envirocar.core.entity.Vehicles;
 
 import java.util.List;
 
-import butterknife.BindView;
-import butterknife.ButterKnife;
-import butterknife.OnClick;
-
 public class CarListFragment extends BottomSheetDialogFragment {
+    private FragmentCarListBinding binding;
 
-    @BindView(R.id.fragment_car_list_view)
     RecyclerView recyclerView;
-   List<Vehicles> vehiclesList;
-
-
+    List<Vehicles> vehiclesList;
 
     @Nullable
     @Override
     public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
+        binding = FragmentCarListBinding.inflate(inflater, container, false);
 
-        View view = inflater.inflate(R.layout.fragment_car_list, container, false);
-        ButterKnife.bind(this, view);
+        recyclerView = binding.fragmentCarListView;
+        binding.fragmentCarListLayoutCancel.setOnClickListener(v -> cancelSheet());
+
         CarSelectionAttributeListAdapter carListAdapter = new CarSelectionAttributeListAdapter(getContext(), vehiclesList,
                 new OnCarInteractionCallback() {
 
@@ -69,7 +66,13 @@ public class CarListFragment extends BottomSheetDialogFragment {
         RecyclerView.LayoutManager layoutManager = new LinearLayoutManager(getContext());
         recyclerView.setLayoutManager(layoutManager);
         recyclerView.setAdapter(carListAdapter);
-        return view;
+        return binding.getRoot();
+    }
+
+    @Override
+    public void onDestroyView() {
+        super.onDestroyView();
+        binding = null;
     }
 
     CarListFragment(List<Vehicles> vehiclesList) {
@@ -81,7 +84,6 @@ public class CarListFragment extends BottomSheetDialogFragment {
         super.onDestroy();
     }
 
-    @OnClick(R.id.fragment_car_list_layout_cancel)
     void cancelSheet() {
         dismiss();
     }

--- a/org.envirocar.app/src/org/envirocar/app/views/carselection/CarSelectionActivity.java
+++ b/org.envirocar.app/src/org/envirocar/app/views/carselection/CarSelectionActivity.java
@@ -19,7 +19,6 @@
 package org.envirocar.app.views.carselection;
 
 import android.content.Context;
-import android.content.DialogInterface;
 import android.os.Bundle;
 
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
@@ -38,6 +37,7 @@ import android.widget.TextView;
 
 import org.envirocar.app.BaseApplicationComponent;
 import org.envirocar.app.R;
+import org.envirocar.app.databinding.ActivityCarSelectionLayoutBinding;
 import org.envirocar.app.handler.preferences.CarPreferenceHandler;
 import org.envirocar.app.handler.preferences.UserPreferenceHandler;
 import org.envirocar.app.views.utils.ECAnimationUtils;
@@ -55,9 +55,6 @@ import java.util.Set;
 
 import javax.inject.Inject;
 
-import butterknife.ButterKnife;
-import butterknife.BindView;
-import butterknife.OnClick;
 import io.reactivex.Observable;
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.disposables.Disposable;
@@ -68,23 +65,18 @@ import io.reactivex.schedulers.Schedulers;
  * @author dewall
  */
 public class CarSelectionActivity extends BaseInjectorActivity implements CarSelectionUiListener, CarSelectionCreation {
+    private ActivityCarSelectionLayoutBinding binding;
+
     private static final Logger LOG = Logger.getLogger(CarSelectionActivity.class);
 
     private static final int DURATION_SHEET_ANIMATION = 350;
 
-    @BindView(R.id.activity_car_selection_layout_content)
-    protected View mContentView;
-    @BindView(R.id.envirocar_toolbar)
     protected Toolbar mToolbar;
-    @BindView(R.id.activity_car_selection_layout_exptoolbar)
     protected Toolbar mExpToolbar;
-    @BindView(R.id.actvity_car_selection_layout_loading)
     protected View loadingView;
 
-    @BindView(R.id.activity_car_selection_new_car_fab)
     protected FloatingActionButton mFab;
 
-    @BindView(R.id.activity_car_selection_layout_carlist)
     protected ListView mCarListView;
 
     @Inject
@@ -94,15 +86,10 @@ public class CarSelectionActivity extends BaseInjectorActivity implements CarSel
     @Inject
     protected UserPreferenceHandler mUserHandler;
 
-    @BindView(R.id.layout_general_info_background)
     protected View infoBackground;
-    @BindView(R.id.layout_general_info_background_img)
     protected ImageView infoBackgroundImg;
-    @BindView(R.id.layout_general_info_background_firstline)
     protected TextView infoBackgroundFirst;
-    @BindView(R.id.layout_general_info_background_secondline)
     protected TextView infoBackgroundSecond;
-    @BindView(R.id.activity_car_selection_header)
     protected View headerView;
 
     private CarSelectionAddCarFragment addCarFragment;
@@ -119,11 +106,22 @@ public class CarSelectionActivity extends BaseInjectorActivity implements CarSel
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
-        // Set the content view of this activity.
-        setContentView(R.layout.activity_car_selection_layout);
+        binding = ActivityCarSelectionLayoutBinding.inflate(getLayoutInflater());
+        final View view = binding.getRoot();
+        setContentView(view);
 
-        // Inject all annotated views.
-        ButterKnife.bind(this);
+        mToolbar = binding.envirocarToolbar.envirocarToolbar;
+        mExpToolbar = binding.activityCarSelectionLayoutExptoolbar;
+        loadingView = binding.actvityCarSelectionLayoutLoading;
+        mFab = binding.activityCarSelectionNewCarFab;
+        mCarListView = binding.activityCarSelectionLayoutCarlist;
+        infoBackground = binding.layoutGeneralInfoBackground.getRoot();
+        infoBackgroundImg = binding.layoutGeneralInfoBackground.layoutGeneralInfoBackgroundImg;
+        infoBackgroundFirst = binding.layoutGeneralInfoBackground.layoutGeneralInfoBackgroundFirstline;
+        infoBackgroundSecond = binding.layoutGeneralInfoBackground.layoutGeneralInfoBackgroundSecondline;
+        headerView = binding.activityCarSelectionHeader;
+
+        mFab.setOnClickListener(v -> onClickNewCarButton());
 
         // Set the toolbar as default actionbar.
         setSupportActionBar(mToolbar);
@@ -166,7 +164,6 @@ public class CarSelectionActivity extends BaseInjectorActivity implements CarSel
 
     // Set the onClick listener for the FloatingActionButton. When triggered, the sheet view
     // gets shown.
-    @OnClick(R.id.activity_car_selection_new_car_fab)
     public void onClickNewCarButton() {
         showAddCarFragment();
     }

--- a/org.envirocar.app/src/org/envirocar/app/views/carselection/CarSelectionActivity.java
+++ b/org.envirocar.app/src/org/envirocar/app/views/carselection/CarSelectionActivity.java
@@ -65,11 +65,11 @@ import io.reactivex.schedulers.Schedulers;
  * @author dewall
  */
 public class CarSelectionActivity extends BaseInjectorActivity implements CarSelectionUiListener, CarSelectionCreation {
-    private ActivityCarSelectionLayoutBinding binding;
-
     private static final Logger LOG = Logger.getLogger(CarSelectionActivity.class);
 
     private static final int DURATION_SHEET_ANIMATION = 350;
+
+    private ActivityCarSelectionLayoutBinding binding;
 
     protected Toolbar mToolbar;
     protected Toolbar mExpToolbar;

--- a/org.envirocar.app/src/org/envirocar/app/views/carselection/CarSelectionAddCarFragment.java
+++ b/org.envirocar.app/src/org/envirocar/app/views/carselection/CarSelectionAddCarFragment.java
@@ -55,9 +55,9 @@ import io.reactivex.observers.DisposableObserver;
 import io.reactivex.schedulers.Schedulers;
 
 public class CarSelectionAddCarFragment extends BaseInjectorFragment {
-    private ActivityCarSelectionNewcarFragmentBinding binding;
-
     private static final Logger LOG = Logger.getLogger(CarSelectionAddCarFragment.class);
+
+    private ActivityCarSelectionNewcarFragmentBinding binding;
 
     protected Toolbar toolbar;
     protected View toolbarExp;
@@ -126,6 +126,12 @@ public class CarSelectionAddCarFragment extends BaseInjectorFragment {
         });
 
         return view;
+    }
+
+    @Override
+    public void onDestroyView() {
+        super.onDestroyView();
+        binding = null;
     }
 
     @Override

--- a/org.envirocar.app/src/org/envirocar/app/views/carselection/CarSelectionAddCarFragment.java
+++ b/org.envirocar.app/src/org/envirocar/app/views/carselection/CarSelectionAddCarFragment.java
@@ -22,7 +22,6 @@ package org.envirocar.app.views.carselection;
 import android.app.Activity;
 import android.content.Context;
 import android.os.Bundle;
-import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -38,10 +37,10 @@ import androidx.viewpager.widget.ViewPager;
 
 import org.envirocar.app.BaseApplicationComponent;
 import org.envirocar.app.R;
+import org.envirocar.app.databinding.ActivityCarSelectionNewcarFragmentBinding;
 import org.envirocar.app.injection.BaseInjectorFragment;
 import org.envirocar.app.views.utils.ECAnimationUtils;
 import org.envirocar.core.entity.Manufacturers;
-import org.envirocar.core.entity.Vehicles;
 import org.envirocar.core.logging.Logger;
 import org.envirocar.storage.EnviroCarVehicleDB;
 
@@ -49,30 +48,21 @@ import java.util.List;
 
 import javax.inject.Inject;
 
-import butterknife.BindView;
-import butterknife.ButterKnife;
-import butterknife.OnClick;
 import info.hoang8f.android.segmented.SegmentedGroup;
 import io.reactivex.Observable;
-import io.reactivex.Single;
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.observers.DisposableObserver;
-import io.reactivex.observers.DisposableSingleObserver;
 import io.reactivex.schedulers.Schedulers;
 
 public class CarSelectionAddCarFragment extends BaseInjectorFragment {
+    private ActivityCarSelectionNewcarFragmentBinding binding;
+
     private static final Logger LOG = Logger.getLogger(CarSelectionAddCarFragment.class);
 
-
-    @BindView(R.id.envirocar_toolbar)
     protected Toolbar toolbar;
-    @BindView(R.id.activity_car_selection_newcar_toolbar_exp)
     protected View toolbarExp;
-    @BindView(R.id.activity_car_selection_top)
     protected View topView;
-    @BindView(R.id.carSelectionSegmentedGroup)
     protected SegmentedGroup segmentedGroup;
-    @BindView(R.id.activity_car_selection_newcar_content_view)
     protected ViewPager mViewPager;
 
     @Inject
@@ -86,9 +76,14 @@ public class CarSelectionAddCarFragment extends BaseInjectorFragment {
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle
             savedInstanceState) {
         super.onCreateView(inflater, container, savedInstanceState);
+        binding = ActivityCarSelectionNewcarFragmentBinding.inflate(inflater, container, false);
+        final View view = binding.getRoot();
 
-        View view = inflater.inflate(R.layout.activity_car_selection_newcar_fragment, container, false);
-        ButterKnife.bind(this, view);
+        toolbar = binding.envirocarToolbar.envirocarToolbar;
+        toolbarExp = binding.activityCarSelectionNewcarToolbarExp;
+        topView = binding.activityCarSelectionTop;
+        segmentedGroup = binding.carSelectionSegmentedGroup;
+        mViewPager = binding.activityCarSelectionNewcarContentView;
 
         toolbar.setNavigationIcon(R.drawable.ic_close_white_24dp);
         toolbar.setNavigationOnClickListener(v -> {
@@ -122,16 +117,11 @@ public class CarSelectionAddCarFragment extends BaseInjectorFragment {
         segmentedGroup.check(R.id.attributesSegmentedButton);
 
         segmentedGroup.setOnCheckedChangeListener((radioGroup, i) -> {
-            switch (i) {
-                case R.id.attributesSegmentedButton:
-                    mViewPager.setCurrentItem(0);
-                    break;
-                case R.id.HsnTsnSegmentedButton:
-                    mViewPager.setCurrentItem(1);
-                    break;
-                default:
-                    break;
+            if (i == R.id.attributesSegmentedButton) {
+                mViewPager.setCurrentItem(0);
 
+            } else if (i == R.id.HsnTsnSegmentedButton) {
+                mViewPager.setCurrentItem(1);
             }
         });
 

--- a/org.envirocar.app/src/org/envirocar/app/views/carselection/CarSelectionAttributeListAdapter.java
+++ b/org.envirocar.app/src/org/envirocar/app/views/carselection/CarSelectionAttributeListAdapter.java
@@ -31,12 +31,10 @@ import androidx.recyclerview.widget.RecyclerView;
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 
 import org.envirocar.app.R;
+import org.envirocar.app.databinding.CarDetailCardLayoutBinding;
 import org.envirocar.core.entity.Vehicles;
 
 import java.util.List;
-
-import butterknife.BindView;
-import butterknife.ButterKnife;
 
 public class CarSelectionAttributeListAdapter extends RecyclerView.Adapter<CarSelectionAttributeListAdapter.CarSelectionViewHolder> {
 
@@ -54,8 +52,8 @@ public class CarSelectionAttributeListAdapter extends RecyclerView.Adapter<CarSe
     @NonNull
     @Override
     public CarSelectionAttributeListAdapter.CarSelectionViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
-        View view = LayoutInflater.from(context).inflate(R.layout.car_detail_card_layout, parent, false);
-        return new CarSelectionViewHolder(view);
+        final CarDetailCardLayoutBinding binding = CarDetailCardLayoutBinding.inflate(LayoutInflater.from(parent.getContext()), parent, false);
+        return new CarSelectionViewHolder(binding);
     }
 
     @Override
@@ -118,32 +116,31 @@ public class CarSelectionAttributeListAdapter extends RecyclerView.Adapter<CarSe
 
     public class CarSelectionViewHolder extends RecyclerView.ViewHolder {
 
-        @BindView(R.id.car_layout_manufacturer_name)
         TextView manufacturerName;
-        @BindView(R.id.car_layout_vehcile_name)
         TextView vehicleName;
-        @BindView(R.id.car_layout_construction_year)
         TextView constructionYear;
-        @BindView(R.id.car_layout_fuel_type)
         TextView fuelType;
-        @BindView(R.id.car_layout_engine_capacity)
         TextView engineCapacity;
-        @BindView(R.id.car_layout_power)
         TextView power;
-        @BindView(R.id.car_layout_card)
         View carDetailView;
-        @BindView(R.id.expandView)
         ImageView imageView1;
-        @BindView(R.id.car_layout_engine_view)
         View engineView;
-        @BindView(R.id.car_layout_expanded_card)
         View expandCard;
-        @BindView(R.id.car_layout_hsn_tsn)
         TextView hsnTsn;
 
-        public CarSelectionViewHolder(@NonNull View itemView) {
-            super(itemView);
-            ButterKnife.bind(this, itemView);
+        public CarSelectionViewHolder(CarDetailCardLayoutBinding binding) {
+            super(binding.getRoot());
+            manufacturerName = binding.carLayoutManufacturerName;
+            vehicleName = binding.carLayoutVehcileName;
+            constructionYear = binding.carLayoutConstructionYear;
+            fuelType = binding.carLayoutFuelType;
+            engineCapacity = binding.carLayoutEngineCapacity;
+            power = binding.carLayoutPower;
+            carDetailView = binding.carLayoutCard;
+            imageView1 = binding.expandView;
+            engineView = binding.carLayoutEngineView;
+            expandCard = binding.carLayoutExpandedCard;
+            hsnTsn = binding.carLayoutHsnTsn;
         }
     }
 }

--- a/org.envirocar.app/src/org/envirocar/app/views/carselection/CarSelectionAttributesFragment.java
+++ b/org.envirocar.app/src/org/envirocar/app/views/carselection/CarSelectionAttributesFragment.java
@@ -83,7 +83,7 @@ public class CarSelectionAttributesFragment extends BaseInjectorFragment {
     protected AutoCompleteTextView emissionClassSelection;
     protected TextView searchButton;
 
-    private TextWatcher manufactureEditTextWatcher = new TextWatcher() {
+    private final TextWatcher manufactureEditTextWatcher = new TextWatcher() {
         @Override
         public void beforeTextChanged(CharSequence s, int start, int count, int after) {}
         @Override
@@ -94,7 +94,7 @@ public class CarSelectionAttributesFragment extends BaseInjectorFragment {
         }
     };
 
-    private TextWatcher modelEditTextWatcher = new TextWatcher() {
+    private final TextWatcher modelEditTextWatcher = new TextWatcher() {
         @Override
         public void beforeTextChanged(CharSequence s, int start, int count, int after) {}
         @Override
@@ -105,7 +105,7 @@ public class CarSelectionAttributesFragment extends BaseInjectorFragment {
         }
     };
 
-    private TextWatcher yearEditTextWatcher = new TextWatcher() {
+    private final TextWatcher yearEditTextWatcher = new TextWatcher() {
         @Override
         public void beforeTextChanged(CharSequence s, int start, int count, int after) {}
         @Override

--- a/org.envirocar.app/src/org/envirocar/app/views/carselection/CarSelectionHsnTsnFragment.java
+++ b/org.envirocar.app/src/org/envirocar/app/views/carselection/CarSelectionHsnTsnFragment.java
@@ -1,18 +1,18 @@
 /**
  * Copyright (C) 2013 - 2021 the enviroCar community
- *
+ * <p>
  * This file is part of the enviroCar app.
- *
+ * <p>
  * The enviroCar app is free software: you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as published
  * by the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- *
+ * <p>
  * The enviroCar app is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
  * Public License for more details.
- *
+ * <p>
  * You should have received a copy of the GNU General Public License along
  * with the enviroCar app. If not, see http://www.gnu.org/licenses/.
  */
@@ -34,6 +34,7 @@ import android.widget.TextView;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.core.content.ContextCompat;
 
 import com.jakewharton.rxbinding3.widget.RxTextView;
 
@@ -108,11 +109,19 @@ public class CarSelectionHsnTsnFragment extends BaseInjectorFragment {
         fetchAllVehicles();
         reactiveTexFieldCheck();
         focusChangeListener();
-        error = getResources().getDrawable(R.drawable.ic_error_red_24dp);
-        error.setBounds(-50, 0, 0, error.getIntrinsicHeight());
+        error = ContextCompat.getDrawable(requireContext(), R.drawable.ic_error_red_24dp);
+        if (error != null) {
+            error.setBounds(-50, 0, 0, error.getIntrinsicHeight());
+        }
         hsnEditText.setOnItemClickListener((parent, view1, position, id) -> requestNextTextFieldFocus(hsnEditText));
         tsnEditText.setOnItemClickListener((parent, view1, position, id) -> requestNextTextFieldFocus(tsnEditText));
         return view;
+    }
+
+    @Override
+    public void onDestroyView() {
+        super.onDestroyView();
+        binding = null;
     }
 
     @Override
@@ -239,7 +248,7 @@ public class CarSelectionHsnTsnFragment extends BaseInjectorFragment {
 
                     @Override
                     public void onError(Throwable e) {
-                        Log.i("vehicleFetch():",e.getMessage());
+                        Log.i("vehicleFetch():", e.getMessage());
                     }
 
                     @Override

--- a/org.envirocar.app/src/org/envirocar/app/views/carselection/CarSelectionHsnTsnFragment.java
+++ b/org.envirocar.app/src/org/envirocar/app/views/carselection/CarSelectionHsnTsnFragment.java
@@ -26,6 +26,7 @@ import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.view.inputmethod.EditorInfo;
 import android.view.inputmethod.InputMethodManager;
 import android.widget.AutoCompleteTextView;
 import android.widget.ListAdapter;
@@ -38,6 +39,7 @@ import com.jakewharton.rxbinding3.widget.RxTextView;
 
 import org.envirocar.app.BaseApplicationComponent;
 import org.envirocar.app.R;
+import org.envirocar.app.databinding.FragmentCarSelectionHsnTsnBinding;
 import org.envirocar.app.injection.BaseInjectorFragment;
 import org.envirocar.core.entity.Manufacturers;
 import org.envirocar.core.entity.Vehicles;
@@ -53,10 +55,6 @@ import java.util.concurrent.TimeUnit;
 
 import javax.inject.Inject;
 
-import butterknife.BindView;
-import butterknife.ButterKnife;
-import butterknife.OnClick;
-import butterknife.OnEditorAction;
 import io.reactivex.Observable;
 import io.reactivex.Scheduler;
 import io.reactivex.Single;
@@ -67,10 +65,9 @@ import io.reactivex.observers.DisposableSingleObserver;
 import io.reactivex.schedulers.Schedulers;
 
 public class CarSelectionHsnTsnFragment extends BaseInjectorFragment {
+    private FragmentCarSelectionHsnTsnBinding binding;
 
-    @BindView(R.id.fragment_hsntsn_hsn_input)
     protected AutoCompleteTextView hsnEditText;
-    @BindView(R.id.fragment_hsntsn_tsn_input)
     protected AutoCompleteTextView tsnEditText;
     protected BottomSheetFragment bottomSheetFragment;
 
@@ -95,8 +92,19 @@ public class CarSelectionHsnTsnFragment extends BaseInjectorFragment {
     @Override
     public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
         super.onCreateView(inflater, container, savedInstanceState);
-        View view = inflater.inflate(R.layout.fragment_car_selection_hsn_tsn, container, false);
-        ButterKnife.bind(this, view);
+        binding = FragmentCarSelectionHsnTsnBinding.inflate(inflater, container, false);
+        final View view = binding.getRoot();
+        hsnEditText = binding.fragmentHsntsnHsnInput;
+        tsnEditText = binding.fragmentHsntsnTsnInput;
+
+        binding.fragmentSearchVehicle.setOnClickListener(v -> onSearchClicked());
+        binding.fragmentHsntsnTsnInput.setOnEditorActionListener((v, action, event) -> {
+            if (action == EditorInfo.IME_ACTION_DONE) {
+                onSearchClicked();
+            }
+            return true;
+        });
+
         fetchAllVehicles();
         reactiveTexFieldCheck();
         focusChangeListener();
@@ -124,7 +132,6 @@ public class CarSelectionHsnTsnFragment extends BaseInjectorFragment {
         hideKeyboard(textView);
     }
 
-    @OnClick(R.id.fragment_search_vehicle)
     protected void onSearchClicked() {
         String hsnWithManufactureName = hsnEditText.getText().toString().trim();
         String tsn = tsnEditText.getText().toString().trim();
@@ -172,7 +179,6 @@ public class CarSelectionHsnTsnFragment extends BaseInjectorFragment {
         baseApplicationComponent.inject(this);
     }
 
-    @OnEditorAction(R.id.fragment_hsntsn_tsn_input)
     protected void implicitSubmit() {
         onSearchClicked();
     }

--- a/org.envirocar.app/src/org/envirocar/app/views/carselection/CarSelectionListAdapter.java
+++ b/org.envirocar.app/src/org/envirocar/app/views/carselection/CarSelectionListAdapter.java
@@ -112,6 +112,7 @@ public class CarSelectionListAdapter extends ArrayAdapter<Car> {
                     parent,
                     false
             );
+            convertView = binding.getRoot();
             holder = new CarViewHolder(binding);
             convertView.setTag(holder);
         } else {

--- a/org.envirocar.app/src/org/envirocar/app/views/carselection/CarSelectionListAdapter.java
+++ b/org.envirocar.app/src/org/envirocar/app/views/carselection/CarSelectionListAdapter.java
@@ -34,14 +34,12 @@ import android.widget.TextView;
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 
 import org.envirocar.app.R;
+import org.envirocar.app.databinding.ActivityCarSelectionLayoutCarlistEntryBinding;
 import org.envirocar.core.entity.Car;
 import org.envirocar.core.logging.Logger;
 import org.envirocar.core.utils.CarUtils;
 
 import java.util.List;
-
-import butterknife.ButterKnife;
-import butterknife.BindView;
 
 /**
  * @author dewall
@@ -109,9 +107,12 @@ public class CarSelectionListAdapter extends ArrayAdapter<Car> {
 
         CarViewHolder holder = null;
         if (convertView == null) {
-            convertView = inflater.inflate(R.layout
-                    .activity_car_selection_layout_carlist_entry, parent, false);
-            holder = new CarViewHolder(convertView);
+            final ActivityCarSelectionLayoutCarlistEntryBinding binding = ActivityCarSelectionLayoutCarlistEntryBinding.inflate(
+                    inflater,
+                    parent,
+                    false
+            );
+            holder = new CarViewHolder(binding);
             convertView.setTag(holder);
         } else {
             holder = (CarViewHolder) convertView.getTag();
@@ -234,25 +235,24 @@ public class CarSelectionListAdapter extends ArrayAdapter<Car> {
 
         protected final View mCoreView;
 
-        @BindView(R.id.activity_car_selection_layout_carlist_entry_icon)
         protected ImageView iconView;
-        @BindView(R.id.activity_car_selection_layout_carlist_entry_firstline)
         protected TextView firstLine;
-        @BindView(R.id.activity_car_selection_layout_carlist_entry_secondline)
         protected TextView secondLine;
-        @BindView(R.id.activity_car_selection_layout_carlist_entry_radio)
         protected RadioButton mRadioButton;
-        @BindView(R.id.activity_car_selection_layout_carlist_delete_icon)
         protected ImageButton mDeleteButton;
 
         /**
          * Constructor.
          *
-         * @param view
+         * @param binding the binding of the view.
          */
-        CarViewHolder(View view) {
-            this.mCoreView = view;
-            ButterKnife.bind(this, view);
+        CarViewHolder(ActivityCarSelectionLayoutCarlistEntryBinding binding) {
+            mCoreView = binding.getRoot();
+            iconView = binding.activityCarSelectionLayoutCarlistEntryIcon;
+            firstLine = binding.activityCarSelectionLayoutCarlistEntryFirstline;
+            secondLine = binding.activityCarSelectionLayoutCarlistEntrySecondline;
+            mRadioButton = binding.activityCarSelectionLayoutCarlistEntryRadio;
+            mDeleteButton = binding.activityCarSelectionLayoutCarlistDeleteIcon;
         }
     }
 }

--- a/org.envirocar.app/src/org/envirocar/app/views/dashboard/DashboardFragment.java
+++ b/org.envirocar.app/src/org/envirocar/app/views/dashboard/DashboardFragment.java
@@ -126,12 +126,11 @@ import static android.app.Activity.RESULT_OK;
  * @author dewall
  */
 public class DashboardFragment extends BaseInjectorFragment {
-
-    private FragmentDashboardViewNewBinding binding;
-
     private static final Logger LOG = Logger.getLogger(DashboardFragment.class);
 
     private static final int LOCATION_PERMISSION_REQUEST_CODE = 1203;
+
+    private FragmentDashboardViewNewBinding binding;
 
     // View Injections
     protected Toolbar toolbar;

--- a/org.envirocar.app/src/org/envirocar/app/views/logbook/LogbookActivity.java
+++ b/org.envirocar.app/src/org/envirocar/app/views/logbook/LogbookActivity.java
@@ -18,13 +18,6 @@
  */
 package org.envirocar.app.views.logbook;
 
-import android.app.Application;
-import android.content.Context;
-import android.net.ConnectivityManager;
-import android.net.Network;
-import android.net.NetworkCapabilities;
-import android.net.NetworkInfo;
-import android.os.Build;
 import android.os.Bundle;
 
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
@@ -39,10 +32,10 @@ import android.widget.TextView;
 
 import org.envirocar.app.BaseApplicationComponent;
 import org.envirocar.app.R;
+import org.envirocar.app.databinding.ActivityLogbookBinding;
 import org.envirocar.app.handler.preferences.CarPreferenceHandler;
 import org.envirocar.app.views.utils.ECAnimationUtils;
 import org.envirocar.core.ContextInternetAccessProvider;
-import org.envirocar.core.InternetAccessProvider;
 import org.envirocar.core.UserManager;
 import org.envirocar.core.entity.Fueling;
 import org.envirocar.core.exception.NotConnectedException;
@@ -57,9 +50,6 @@ import java.util.List;
 
 import javax.inject.Inject;
 
-import butterknife.ButterKnife;
-import butterknife.BindView;
-import butterknife.OnClick;
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.disposables.CompositeDisposable;
 import io.reactivex.observers.DisposableObserver;
@@ -73,6 +63,8 @@ import io.reactivex.schedulers.Schedulers;
 public class LogbookActivity extends BaseInjectorActivity implements LogbookUiListener {
     private static final Logger LOG = Logger.getLogger(LogbookActivity.class);
 
+    private ActivityLogbookBinding binding;
+
     @Inject
     protected CarPreferenceHandler carHandler;
     @Inject
@@ -80,24 +72,15 @@ public class LogbookActivity extends BaseInjectorActivity implements LogbookUiLi
     @Inject
     protected UserManager userManager;
 
-    @BindView(R.id.activity_logbook_toolbar)
     protected Toolbar toolbar;
-    @BindView(R.id.activity_logbook_header)
     protected View headerView;
-    @BindView(R.id.activity_logbook_toolbar_new_fueling_fab)
     protected View newFuelingFab;
-    @BindView(R.id.activity_logbook_toolbar_fuelinglist)
     protected ListView fuelingList;
-    @BindView(R.id.overlay)
     protected View overlayView;
 
-    @BindView(R.id.layout_general_info_background)
     protected View infoBackground;
-    @BindView(R.id.layout_general_info_background_img)
     protected ImageView infoBackgroundImg;
-    @BindView(R.id.layout_general_info_background_firstline)
     protected TextView infoBackgroundFirst;
-    @BindView(R.id.layout_general_info_background_secondline)
     protected TextView infoBackgroundSecond;
 
 //    @BindView(R.id.activity_logbook_not_logged_in)
@@ -121,11 +104,21 @@ public class LogbookActivity extends BaseInjectorActivity implements LogbookUiLi
         LOG.info("onCreate()");
         super.onCreate(savedInstanceState);
 
-        // First, set the content view.
-        setContentView(R.layout.activity_logbook);
+        binding = ActivityLogbookBinding.inflate(getLayoutInflater());
+        View view = binding.getRoot();
+        setContentView(view);
 
-        // Inject the Views.
-        ButterKnife.bind(this);
+        toolbar = binding.activityLogbookToolbar;
+        headerView = binding.activityLogbookHeader;
+        newFuelingFab = binding.activityLogbookToolbarNewFuelingFab;
+        fuelingList = binding.activityLogbookToolbarFuelinglist;
+        overlayView = binding.overlay;
+        infoBackground = binding.layoutGeneralInfoBackground.getRoot();
+        infoBackgroundImg = binding.layoutGeneralInfoBackground.layoutGeneralInfoBackgroundImg;
+        infoBackgroundFirst = binding.layoutGeneralInfoBackground.layoutGeneralInfoBackgroundFirstline;
+        infoBackgroundSecond = binding.layoutGeneralInfoBackground.layoutGeneralInfoBackgroundSecondline;
+
+        newFuelingFab.setOnClickListener(v -> onClickNewFuelingFAB());
 
         // Initializes the Toolbar.
         setSupportActionBar(toolbar);
@@ -187,7 +180,6 @@ public class LogbookActivity extends BaseInjectorActivity implements LogbookUiLi
         super.onBackPressed();
     }
 
-    @OnClick(R.id.activity_logbook_toolbar_new_fueling_fab)
     protected void onClickNewFuelingFAB() {
         if(carHandler.hasCars()) {
             // Click on the fab should first hide the fab and then open the AddFuelingFragment

--- a/org.envirocar.app/src/org/envirocar/app/views/logbook/LogbookActivity.java
+++ b/org.envirocar.app/src/org/envirocar/app/views/logbook/LogbookActivity.java
@@ -105,7 +105,7 @@ public class LogbookActivity extends BaseInjectorActivity implements LogbookUiLi
         super.onCreate(savedInstanceState);
 
         binding = ActivityLogbookBinding.inflate(getLayoutInflater());
-        View view = binding.getRoot();
+        final View view = binding.getRoot();
         setContentView(view);
 
         toolbar = binding.activityLogbookToolbar;

--- a/org.envirocar.app/src/org/envirocar/app/views/logbook/LogbookAddFuelingFragment.java
+++ b/org.envirocar.app/src/org/envirocar/app/views/logbook/LogbookAddFuelingFragment.java
@@ -18,14 +18,9 @@
  */
 package org.envirocar.app.views.logbook;
 
+import static com.mapbox.mapboxsdk.Mapbox.getApplicationContext;
+
 import android.app.Activity;
-import android.app.Application;
-import android.content.Context;
-import android.net.ConnectivityManager;
-import android.net.Network;
-import android.net.NetworkCapabilities;
-import android.net.NetworkInfo;
-import android.os.Build;
 import android.os.Bundle;
 import android.text.InputFilter;
 import android.text.Spanned;
@@ -43,16 +38,17 @@ import androidx.annotation.Nullable;
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.widget.Toolbar;
 
-import com.afollestad.materialdialogs.MaterialDialog;
 import com.google.android.material.snackbar.Snackbar;
 
 import org.envirocar.app.BaseApplicationComponent;
 import org.envirocar.app.R;
+import org.envirocar.app.databinding.ActivityLogbookAddFuelingCardBinding;
 import org.envirocar.app.handler.DAOProvider;
 import org.envirocar.app.handler.preferences.CarPreferenceHandler;
 import org.envirocar.app.injection.BaseInjectorFragment;
 import org.envirocar.app.views.utils.DialogUtils;
-import org.envirocar.app.views.utils.ECAnimationUtils;import org.envirocar.core.ContextInternetAccessProvider;
+import org.envirocar.app.views.utils.ECAnimationUtils;
+import org.envirocar.core.ContextInternetAccessProvider;
 import org.envirocar.core.entity.Car;
 import org.envirocar.core.entity.Fueling;
 import org.envirocar.core.entity.FuelingImpl;
@@ -72,14 +68,10 @@ import java.util.regex.Pattern;
 
 import javax.inject.Inject;
 
-import butterknife.BindView;
-import butterknife.ButterKnife;
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.disposables.CompositeDisposable;
 import io.reactivex.observers.DisposableObserver;
 import io.reactivex.schedulers.Schedulers;
-
-import static com.mapbox.mapboxsdk.Mapbox.getApplicationContext;
 
 /**
  * TODO JavaDoc
@@ -98,38 +90,24 @@ public class LogbookAddFuelingFragment extends BaseInjectorFragment {
         DECIMAL_FORMATTER_3.setDecimalFormatSymbols(symbols);
     }
 
-    @BindView(R.id.logbook_layout_addfueling_toolbar)
+    private ActivityLogbookAddFuelingCardBinding binding;
+
     protected Toolbar addFuelingToolbar;
-    @BindView(R.id.activity_log_book_add_fueling_toolbar_exp)
     protected View addFuelingToolbarExp;
-    @BindView(R.id.activity_logbook_add_fueling_card_content)
     protected View contentView;
-    @BindView(R.id.activity_logbook_add_fueling_card_scrollview)
     protected View contentScrollview;
-    @BindView(R.id.activity_logbook_add_fueling_car_selection)
     protected Spinner addFuelingCarSelection;
-    @BindView(R.id.logbook_add_fueling_milagetext)
     protected EditText addFuelingMilageText;
-    @BindView(R.id.logbook_add_fueling_volumetext)
     protected EditText addFuelingVolumeText;
-    @BindView(R.id.logbook_add_fueling_totalpricetext)
     protected EditText addFuelingTotalCostText;
-    @BindView(R.id.logbook_add_fueling_priceperlitretext)
     protected EditText addFuelingPricePerLitreText;
-    @BindView(R.id.logbook_add_fueling_partialfueling_checkbox)
     protected CheckBox partialFuelingCheckbox;
-    @BindView(R.id.logbook_add_fueling_missedfueling_checkbox)
     protected CheckBox missedFuelingCheckbox;
-    @BindView(R.id.logbook_add_fueling_comment)
     protected EditText commentText;
 
-    @BindView(R.id.layout_general_info_background)
     protected View infoBackground;
-    @BindView(R.id.layout_general_info_background_img)
     protected ImageView infoBackgroundImg;
-    @BindView(R.id.layout_general_info_background_firstline)
     protected TextView infoBackgroundFirst;
-    @BindView(R.id.layout_general_info_background_secondline)
     protected TextView infoBackgroundSecond;
 
     @Inject
@@ -145,11 +123,26 @@ public class LogbookAddFuelingFragment extends BaseInjectorFragment {
             savedInstanceState) {
         super.onCreateView(inflater, container, savedInstanceState);
 
-        // Inflate the view and inject the annotated view.
-        View view = inflater.inflate(R.layout.activity_logbook_add_fueling_card, container, false);
-        ButterKnife.bind(this, view);
+        binding = ActivityLogbookAddFuelingCardBinding.inflate(inflater, container, false);
+        final View view = binding.getRoot();
 
-        view.setOnClickListener(v -> hideKeyboard(view));
+        addFuelingToolbar = binding.logbookLayoutAddfuelingToolbar;
+        addFuelingToolbarExp = binding.activityLogBookAddFuelingToolbarExp;
+        contentView = binding.activityLogbookAddFuelingCardContent;
+        contentScrollview = binding.activityLogbookAddFuelingCardScrollview;
+        addFuelingCarSelection = binding.activityLogbookAddFuelingCarSelection;
+        addFuelingMilageText = binding.logbookAddFuelingMilagetext;
+        addFuelingVolumeText = binding.logbookAddFuelingVolumetext;
+        addFuelingTotalCostText = binding.logbookAddFuelingTotalpricetext;
+        addFuelingPricePerLitreText = binding.logbookAddFuelingPriceperlitretext;
+        partialFuelingCheckbox = binding.logbookAddFuelingPartialfuelingCheckbox;
+        missedFuelingCheckbox = binding.logbookAddFuelingMissedfuelingCheckbox;
+        commentText = binding.logbookAddFuelingComment;
+        infoBackground = binding.layoutGeneralInfoBackground.getRoot();
+        infoBackgroundImg = binding.layoutGeneralInfoBackground.layoutGeneralInfoBackgroundImg;
+        infoBackgroundFirst = binding.layoutGeneralInfoBackground.layoutGeneralInfoBackgroundFirstline;
+        infoBackgroundSecond = binding.layoutGeneralInfoBackground.layoutGeneralInfoBackgroundSecondline;
+
         contentView.setOnClickListener(v -> hideKeyboard(contentView));
 
         addFuelingToolbar.setNavigationIcon(R.drawable.ic_close_white_24dp);

--- a/org.envirocar.app/src/org/envirocar/app/views/logbook/LogbookCarSpinnerAdapter.java
+++ b/org.envirocar.app/src/org/envirocar/app/views/logbook/LogbookCarSpinnerAdapter.java
@@ -61,6 +61,7 @@ public class LogbookCarSpinnerAdapter extends ArrayAdapter<Car> {
         if (convertView == null) {
             final LayoutInflater inflater = LayoutInflater.from(getContext());
             final ActivityLogbookCarSpinnerEntryBinding binding = ActivityLogbookCarSpinnerEntryBinding.inflate(inflater, parent, false);
+            convertView = binding.getRoot();
             holder = new CarSpinnerEntryHolder(binding);
             convertView.setTag(holder);
         } else {

--- a/org.envirocar.app/src/org/envirocar/app/views/logbook/LogbookCarSpinnerAdapter.java
+++ b/org.envirocar.app/src/org/envirocar/app/views/logbook/LogbookCarSpinnerAdapter.java
@@ -26,12 +26,10 @@ import android.widget.ArrayAdapter;
 import android.widget.TextView;
 
 import org.envirocar.app.R;
+import org.envirocar.app.databinding.ActivityLogbookCarSpinnerEntryBinding;
 import org.envirocar.core.entity.Car;
 
 import java.util.List;
-
-import butterknife.ButterKnife;
-import butterknife.BindView;
 
 /**
  * TODO JavaDoc
@@ -61,12 +59,9 @@ public class LogbookCarSpinnerAdapter extends ArrayAdapter<Car> {
 
         CarSpinnerEntryHolder holder = null;
         if (convertView == null) {
-            // Then inflate a new view for the car and create a holder
-            LayoutInflater inflater = (LayoutInflater) getContext().getSystemService(Context
-                    .LAYOUT_INFLATER_SERVICE);
-            convertView = inflater.inflate(R.layout.activity_logbook_car_spinner_entry,
-                    parent, false);
-            holder = new CarSpinnerEntryHolder(convertView);
+            final LayoutInflater inflater = LayoutInflater.from(getContext());
+            final ActivityLogbookCarSpinnerEntryBinding binding = ActivityLogbookCarSpinnerEntryBinding.inflate(inflater, parent, false);
+            holder = new CarSpinnerEntryHolder(binding);
             convertView.setTag(holder);
         } else {
             holder = (CarSpinnerEntryHolder) convertView.getTag();
@@ -87,19 +82,18 @@ public class LogbookCarSpinnerAdapter extends ArrayAdapter<Car> {
 
     static class CarSpinnerEntryHolder {
 
-        @BindView(R.id.activity_logbook_car_spinner_entry_firstline)
         protected TextView title;
-        @BindView(R.id.activity_logbook_car_spinner_entry_secondline)
         protected TextView secondLine;
 
 
         /**
          * Constructor.
          *
-         * @param view the parent view of an entry in the car spinner.
+         * @param binding the binding of the view.
          */
-        CarSpinnerEntryHolder(View view) {
-            ButterKnife.bind(this, view);
+        CarSpinnerEntryHolder(ActivityLogbookCarSpinnerEntryBinding binding) {
+            title = binding.activityLogbookCarSpinnerEntryFirstline;
+            secondLine = binding.activityLogbookCarSpinnerEntrySecondline;
         }
     }
 }

--- a/org.envirocar.app/src/org/envirocar/app/views/logbook/LogbookCarSpinnerAdapter.java
+++ b/org.envirocar.app/src/org/envirocar/app/views/logbook/LogbookCarSpinnerAdapter.java
@@ -44,7 +44,7 @@ public class LogbookCarSpinnerAdapter extends ArrayAdapter<Car> {
      * Constructor.
      *
      * @param context the context of the current scope.
-     * @param objects
+     * @param objects the list of cars.
      */
     public LogbookCarSpinnerAdapter(Context context, List<Car> objects) {
         super(context, R.layout.activity_logbook_car_spinner_entry, R.id

--- a/org.envirocar.app/src/org/envirocar/app/views/logbook/LogbookListAdapter.java
+++ b/org.envirocar.app/src/org/envirocar/app/views/logbook/LogbookListAdapter.java
@@ -38,9 +38,6 @@ import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.List;
 
-import butterknife.ButterKnife;
-import butterknife.BindView;
-
 /**
  * TODO JavaDoc
  *

--- a/org.envirocar.app/src/org/envirocar/app/views/logbook/LogbookListAdapter.java
+++ b/org.envirocar.app/src/org/envirocar/app/views/logbook/LogbookListAdapter.java
@@ -65,14 +65,11 @@ public class LogbookListAdapter extends ArrayAdapter<Fueling> {
 
         final Fueling fueling = fuelings.get(position);
 
-        // Then inflate a new view for the car and create a holder
-        LayoutInflater inflater = (LayoutInflater) getContext().getSystemService(Context
-                .LAYOUT_INFLATER_SERVICE);
-
         FuelingViewHolder holder = null;
         if (convertView == null) {
-            convertView = inflater.inflate(R.layout.activity_logbook_listentry, parent, false);
-            ActivityLogbookListentryBinding binding = ActivityLogbookListentryBinding.bind(convertView);
+            final LayoutInflater inflater = LayoutInflater.from(getContext());
+            final ActivityLogbookListentryBinding binding = ActivityLogbookListentryBinding.inflate(inflater, parent, false);
+            convertView = binding.getRoot();
             holder = new FuelingViewHolder(binding);
             convertView.setTag(holder);
         } else {

--- a/org.envirocar.app/src/org/envirocar/app/views/logbook/LogbookListAdapter.java
+++ b/org.envirocar.app/src/org/envirocar/app/views/logbook/LogbookListAdapter.java
@@ -26,6 +26,7 @@ import android.widget.ArrayAdapter;
 import android.widget.TextView;
 
 import org.envirocar.app.R;
+import org.envirocar.app.databinding.ActivityLogbookListentryBinding;
 import org.envirocar.core.entity.Car;
 import org.envirocar.core.entity.Fueling;
 import org.envirocar.app.views.utils.DateUtils;
@@ -74,7 +75,8 @@ public class LogbookListAdapter extends ArrayAdapter<Fueling> {
         FuelingViewHolder holder = null;
         if (convertView == null) {
             convertView = inflater.inflate(R.layout.activity_logbook_listentry, parent, false);
-            holder = new FuelingViewHolder(convertView);
+            ActivityLogbookListentryBinding binding = ActivityLogbookListentryBinding.bind(convertView);
+            holder = new FuelingViewHolder(binding);
             convertView.setTag(holder);
         } else {
             holder = (FuelingViewHolder) convertView.getTag();
@@ -119,33 +121,32 @@ public class LogbookListAdapter extends ArrayAdapter<Fueling> {
     }
 
     static class FuelingViewHolder {
-        @BindView(R.id.activity_logbook_listentry_date)
         protected TextView dateText;
-        @BindView(R.id.activity_logbook_listentry_kmliter)
         protected TextView kmAndLiter;
-        @BindView(R.id.activity_logbook_listentry_priceperliter)
         protected TextView pricePerLiter;
-        @BindView(R.id.activity_logbook_listentry_totalprice)
         protected TextView totalPrice;
 
-        @BindView(R.id.activity_logbook_listentry_car)
         protected TextView car;
-        @BindView(R.id.activity_logbook_listentry_comment_view)
         protected View commentView;
-        @BindView(R.id.activity_logbook_listentry_comment)
         protected TextView commentText;
-        @BindView(R.id.activity_logbook_listentry_fillup)
         protected View filledUpView;
-        @BindView(R.id.activity_logbook_listentry_missedfillup)
         protected View missedFillUpView;
 
         /**
          * Constructor.
          *
-         * @param view the core view to inject the subviews from.
+         * @param binding the binding of the view.
          */
-        FuelingViewHolder(View view) {
-            ButterKnife.bind(this, view);
+        FuelingViewHolder(ActivityLogbookListentryBinding binding) {
+            dateText = binding.activityLogbookListentryDate;
+            kmAndLiter = binding.activityLogbookListentryKmliter;
+            pricePerLiter = binding.activityLogbookListentryPriceperliter;
+            totalPrice = binding.activityLogbookListentryTotalprice;
+            car = binding.activityLogbookListentryCar;
+            commentView = binding.activityLogbookListentryCommentView;
+            commentText = binding.activityLogbookListentryComment;
+            filledUpView = binding.activityLogbookListentryFillup;
+            missedFillUpView = binding.activityLogbookListentryMissedfillup;
         }
     }
 }

--- a/org.envirocar.app/src/org/envirocar/app/views/login/SignupActivity.java
+++ b/org.envirocar.app/src/org/envirocar/app/views/login/SignupActivity.java
@@ -39,6 +39,7 @@ import android.widget.TextView;
 
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AlertDialog;
+import androidx.core.content.ContextCompat;
 
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import com.google.android.material.snackbar.Snackbar;
@@ -47,6 +48,7 @@ import com.jakewharton.rxbinding3.widget.RxTextView;
 
 import org.envirocar.app.BaseApplicationComponent;
 import org.envirocar.app.R;
+import org.envirocar.app.databinding.ActivitySignupBinding;
 import org.envirocar.app.handler.DAOProvider;
 import org.envirocar.app.handler.agreement.AgreementManager;
 import org.envirocar.app.handler.preferences.UserPreferenceHandler;
@@ -66,9 +68,6 @@ import java.util.regex.Pattern;
 
 import javax.inject.Inject;
 
-import butterknife.BindView;
-import butterknife.ButterKnife;
-import butterknife.OnClick;
 import io.reactivex.Scheduler;
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.disposables.Disposable;
@@ -93,6 +92,8 @@ public class SignupActivity extends BaseInjectorActivity {
         context.startActivity(intent);
     }
 
+    private ActivitySignupBinding binding;
+
     // Inject Dependencies
     @Inject
     protected UserPreferenceHandler userHandler;
@@ -102,21 +103,13 @@ public class SignupActivity extends BaseInjectorActivity {
     protected AgreementManager agreementManager;
 
     // Injected Views
-    @BindView(R.id.activity_signup_username_input)
     protected EditText usernameEditText;
-    @BindView(R.id.activity_signup_email_input)
     protected EditText emailEditText;
-    @BindView(R.id.activity_signup_password_1)
     protected EditText password1EditText;
-    @BindView(R.id.activity_signup_password_2)
     protected EditText password2EditText;
-    @BindView(R.id.activity_signup_tou_checkbox)
     protected CheckBox touCheckbox;
-    @BindView(R.id.activity_signup_tou_text)
     protected TextView touText;
-    @BindView(R.id.activity_signup_ps_checkbox)
     protected CheckBox psCheckbox;
-    @BindView(R.id.activity_signup_ps_text)
     protected TextView psText;
 
     private final Scheduler.Worker mainThreadWorker = AndroidSchedulers.mainThread().createWorker();
@@ -133,17 +126,35 @@ public class SignupActivity extends BaseInjectorActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        setContentView(R.layout.activity_signup);
+
+        binding = ActivitySignupBinding.inflate(getLayoutInflater());
+        final View view = binding.getRoot();
+        setContentView(view);
+
+        usernameEditText = binding.activitySignupUsernameInput;
+        emailEditText = binding.activitySignupEmailInput;
+        password1EditText = binding.activitySignupPassword1;
+        password2EditText = binding.activitySignupPassword2;
+        touCheckbox = binding.activitySignupTouCheckbox;
+        touText = binding.activitySignupTouText;
+        psCheckbox = binding.activitySignupPsCheckbox;
+        psText = binding.activitySignupPsText;
+
+        binding.imageView.setOnClickListener(v -> closeKeyboard());
+        binding.activitySignupLoginButton.setOnClickListener(v -> onSwitchToRegister());
+        binding.activitySignupRegisterButton.setOnClickListener(v -> onRegisterAccountButtonClicked());
+
         getWindow().setNavigationBarColor(getResources().getColor(R.color.cario_color_primary_dark));
 
-        // inject the views
-        ButterKnife.bind(this);
+        errorPassword = ContextCompat.getDrawable(this, R.drawable.ic_error_red_24dp);
+        if (errorPassword != null) {
+            errorPassword.setBounds(-70,0,0, errorPassword.getIntrinsicHeight());
+        }
 
-        errorPassword = getResources().getDrawable(R.drawable.ic_error_red_24dp);
-        errorPassword.setBounds(-70,0,0, errorPassword.getIntrinsicHeight());
-
-        errorUsername = getResources().getDrawable(R.drawable.ic_error_red_24dp);
-        errorUsername.setBounds(0, 0, errorUsername.getIntrinsicWidth(), errorUsername.getIntrinsicHeight());
+        errorUsername = ContextCompat.getDrawable(this, R.drawable.ic_error_red_24dp);
+        if (errorUsername != null) {
+            errorUsername.setBounds(0, 0, errorUsername.getIntrinsicWidth(), errorUsername.getIntrinsicHeight());
+        }
 
         // make terms of use and privacy statement clickable
         this.makeClickableTextLinks();
@@ -158,7 +169,6 @@ public class SignupActivity extends BaseInjectorActivity {
         }
     }
 
-    @OnClick(R.id.imageView)
     protected void closeKeyboard(){
         View view = this.getCurrentFocus();
         if (view != null) {
@@ -167,13 +177,11 @@ public class SignupActivity extends BaseInjectorActivity {
         }
     }
 
-    @OnClick(R.id.activity_signup_login_button)
     protected void onSwitchToRegister() {
         Intent intent = new Intent(this, SigninActivity.class);
         startActivity(intent);
     }
 
-    @OnClick(R.id.activity_signup_register_button)
     protected void onRegisterAccountButtonClicked() {
 
         // We do not want to have dublicate registration processes.

--- a/org.envirocar.app/src/org/envirocar/app/views/obdselection/OBDDeviceListAdapter.java
+++ b/org.envirocar.app/src/org/envirocar/app/views/obdselection/OBDDeviceListAdapter.java
@@ -18,9 +18,14 @@
  */
 package org.envirocar.app.views.obdselection;
 
+import android.Manifest;
 import android.bluetooth.BluetoothDevice;
 import android.content.Context;
+
 import androidx.appcompat.widget.AppCompatRadioButton;
+import androidx.core.app.ActivityCompat;
+
+import android.content.pm.PackageManager;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -30,9 +35,7 @@ import android.widget.ImageView;
 import android.widget.TextView;
 
 import org.envirocar.app.R;
-
-import butterknife.ButterKnife;
-import butterknife.BindView;
+import org.envirocar.app.databinding.ActivityObdSelectionLayoutPairedListEntryBinding;
 
 /**
  * @author dewall
@@ -110,9 +113,10 @@ public class OBDDeviceListAdapter extends ArrayAdapter<BluetoothDevice> {
         ViewHolder holder;
         // Check if an existing view is being reused, otherwise inflate the view
         if (convertView == null) {
-            convertView = LayoutInflater.from(getContext()).inflate(R.layout
-                    .activity_obd_selection_layout_paired_list_entry, parent, false);
-            holder = new ViewHolder(convertView);
+            final ActivityObdSelectionLayoutPairedListEntryBinding binding = ActivityObdSelectionLayoutPairedListEntryBinding
+                    .inflate(LayoutInflater.from(getContext()), parent, false);
+            convertView = binding.getRoot();
+            holder = new ViewHolder(binding);
 
             // if this list is used for a paired list then we show an addition radio button for
             // the selection
@@ -126,7 +130,9 @@ public class OBDDeviceListAdapter extends ArrayAdapter<BluetoothDevice> {
             holder = (ViewHolder) convertView.getTag();
         }
 
-        holder.mTextView.setText(device.getName());
+        if (ActivityCompat.checkSelfPermission(getContext(), Manifest.permission.BLUETOOTH_CONNECT) != PackageManager.PERMISSION_GRANTED) {
+            holder.mTextView.setText(device.getName());
+        }
         holder.mRadioButton.setChecked(false);
 
         // If there exists an already selected bluetooth device and the device of this entry
@@ -214,25 +220,22 @@ public class OBDDeviceListAdapter extends ArrayAdapter<BluetoothDevice> {
 
         public final View mContentView;
 
-        // All the views of a row to lookup for.
-        @BindView(R.id.activity_obd_selection_layout_paired_list_entry_image)
         protected ImageView mImageView;
-        @BindView(R.id.activity_obd_selection_layout_paired_list_entry_text)
         protected TextView mTextView;
-        @BindView(R.id.activity_obd_selection_layout_paired_list_entry_delete)
         protected ImageButton mDeleteButton;
-        @BindView(R.id.activity_obd_selection_layout_paired_list_entry_radio)
         protected AppCompatRadioButton mRadioButton;
 
         /**
          * Constructor.
          *
-         * @param content the parent view of the listrow.
+         * @param binding the binding of the layout.
          */
-        ViewHolder(View content) {
-            this.mContentView = content;
-            // Inject the annotated views.
-            ButterKnife.bind(this, content);
+        ViewHolder(ActivityObdSelectionLayoutPairedListEntryBinding binding) {
+            mContentView = binding.getRoot();
+            mImageView = binding.activityObdSelectionLayoutPairedListEntryImage;
+            mTextView = binding.activityObdSelectionLayoutPairedListEntryText;
+            mDeleteButton = binding.activityObdSelectionLayoutPairedListEntryDelete;
+            mRadioButton = binding.activityObdSelectionLayoutPairedListEntryRadio;
         }
     }
 }

--- a/org.envirocar.app/src/org/envirocar/app/views/obdselection/OBDDeviceListAdapter.java
+++ b/org.envirocar.app/src/org/envirocar/app/views/obdselection/OBDDeviceListAdapter.java
@@ -130,7 +130,7 @@ public class OBDDeviceListAdapter extends ArrayAdapter<BluetoothDevice> {
             holder = (ViewHolder) convertView.getTag();
         }
 
-        if (ActivityCompat.checkSelfPermission(getContext(), Manifest.permission.BLUETOOTH_CONNECT) != PackageManager.PERMISSION_GRANTED) {
+        if (ActivityCompat.checkSelfPermission(getContext(), Manifest.permission.BLUETOOTH_CONNECT) == PackageManager.PERMISSION_GRANTED) {
             holder.mTextView.setText(device.getName());
         }
         holder.mRadioButton.setChecked(false);

--- a/org.envirocar.app/src/org/envirocar/app/views/obdselection/OBDSelectionActivity.java
+++ b/org.envirocar.app/src/org/envirocar/app/views/obdselection/OBDSelectionActivity.java
@@ -19,17 +19,20 @@
 package org.envirocar.app.views.obdselection;
 
 import android.os.Bundle;
-import com.google.android.material.snackbar.Snackbar;
-import androidx.fragment.app.Fragment;
-import androidx.appcompat.widget.Toolbar;
 import android.view.MenuItem;
+import android.view.View;
 import android.widget.Switch;
 import android.widget.TextView;
 
+import androidx.appcompat.widget.Toolbar;
+import androidx.fragment.app.Fragment;
+
+import com.google.android.material.snackbar.Snackbar;
 import com.squareup.otto.Subscribe;
 
 import org.envirocar.app.BaseApplicationComponent;
 import org.envirocar.app.R;
+import org.envirocar.app.databinding.ActivityObdSelectionLayoutBinding;
 import org.envirocar.app.handler.BluetoothHandler;
 import org.envirocar.app.injection.BaseInjectorActivity;
 import org.envirocar.core.events.bluetooth.BluetoothStateChangedEvent;
@@ -40,8 +43,6 @@ import java.lang.reflect.Method;
 
 import javax.inject.Inject;
 
-import butterknife.BindView;
-import butterknife.ButterKnife;
 
 /**
  * @dewall
@@ -50,14 +51,13 @@ public class OBDSelectionActivity extends BaseInjectorActivity implements
         OBDSelectionFragment.ShowSnackbarListener {
     private static final Logger LOGGER = Logger.getLogger(OBDSelectionActivity.class);
 
+    private ActivityObdSelectionLayoutBinding binding;
+
     @Inject
     protected BluetoothHandler mBluetoothHandler;
 
-    @BindView(R.id.activity_obd_selection_layout_toolbar)
     protected Toolbar mToolbar;
-    @BindView(R.id.activity_obd_selection_layout_enablebt_switch)
     protected Switch mSwitch;
-    @BindView(R.id.activity_obd_selection_layout_enablebt_text)
     protected TextView mEnableBTText;
 
     protected Fragment mOBDSelectionFragment;
@@ -72,11 +72,13 @@ public class OBDSelectionActivity extends BaseInjectorActivity implements
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
-        // Set the content view of this activity.
-        setContentView(R.layout.activity_obd_selection_layout);
+        binding = ActivityObdSelectionLayoutBinding.inflate(getLayoutInflater());
+        final View view = binding.getRoot();
+        setContentView(view);
 
-        // Inject all annotated views.
-        ButterKnife.bind(this);
+        mToolbar = binding.activityObdSelectionLayoutToolbar;
+        mSwitch = binding.activityObdSelectionLayoutEnablebtSwitch;
+        mEnableBTText = binding.activityObdSelectionLayoutEnablebtText;
 
         // Set the toolbar as default actionbar.
         setSupportActionBar(mToolbar);

--- a/org.envirocar.app/src/org/envirocar/app/views/obdselection/OBDSelectionFragment.java
+++ b/org.envirocar.app/src/org/envirocar/app/views/obdselection/OBDSelectionFragment.java
@@ -125,6 +125,7 @@ public class OBDSelectionFragment extends BaseInjectorFragment implements EasyPe
         mProgressBar = binding.activityObdSelectionLayoutSearchDevicesProgressbar;
         mRescanImageView = binding.activityObdSelectionLayoutRescanBluetooth;
         mPairedDevicesInfoTextView = binding.activityObdSelectionLayoutPairedDevicesInfo;
+        mNewDevicesInfoTextView = binding.activityObdSelectionLayoutAvailableDevicesInfo;
 
         mRescanImageView.setOnClickListener(v -> rediscover());
 

--- a/org.envirocar.app/src/org/envirocar/app/views/obdselection/OBDSelectionFragment.java
+++ b/org.envirocar.app/src/org/envirocar/app/views/obdselection/OBDSelectionFragment.java
@@ -34,6 +34,7 @@ import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.annotation.RequiresPermission;
 import androidx.appcompat.app.AlertDialog;
 
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
@@ -41,6 +42,7 @@ import com.squareup.otto.Subscribe;
 
 import org.envirocar.app.BaseApplicationComponent;
 import org.envirocar.app.R;
+import org.envirocar.app.databinding.ActivityObdSelectionFragmentBinding;
 import org.envirocar.app.handler.BluetoothHandler;
 import org.envirocar.app.injection.BaseInjectorFragment;
 import org.envirocar.app.views.utils.DialogUtils;
@@ -49,15 +51,11 @@ import org.envirocar.core.events.bluetooth.BluetoothStateChangedEvent;
 import org.envirocar.core.logging.Logger;
 import org.jetbrains.annotations.NotNull;
 
-import java.lang.IllegalStateException;
 import java.util.List;
 import java.util.Set;
 
 import javax.inject.Inject;
 
-import butterknife.BindView;
-import butterknife.ButterKnife;
-import butterknife.OnClick;
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.observers.DisposableObserver;
@@ -74,6 +72,8 @@ import pub.devrel.easypermissions.PermissionRequest;
 public class OBDSelectionFragment extends BaseInjectorFragment implements EasyPermissions.PermissionCallbacks {
     private static final Logger LOGGER = Logger.getLogger(OBDSelectionFragment.class);
 
+    private ActivityObdSelectionFragmentBinding binding;
+
     @Override
     protected void injectDependencies(BaseApplicationComponent baseApplicationComponent) {
         baseApplicationComponent.inject(this);
@@ -89,22 +89,14 @@ public class OBDSelectionFragment extends BaseInjectorFragment implements EasyPe
     @Inject
     protected BluetoothHandler mBluetoothHandler;
 
-    @BindView(R.id.activity_obd_selection_layout_content)
     protected View mContentView;
-    @BindView(R.id.activity_obd_selection_layout_paired_devices_text)
     protected TextView mPairedDevicesTextView;
-    @BindView(R.id.activity_obd_selection_layout_paired_devices_list)
     protected ListView mPairedDevicesListView;
-    @BindView(R.id.activity_obd_selection_layout_available_devices_list)
     protected ListView mNewDevicesListView;
-    @BindView(R.id.activity_obd_selection_layout_search_devices_progressbar)
     protected ProgressBar mProgressBar;
-    @BindView(R.id.activity_obd_selection_layout_rescan_bluetooth)
     protected ImageView mRescanImageView;
 
-    @BindView(R.id.activity_obd_selection_layout_paired_devices_info)
     protected TextView mPairedDevicesInfoTextView;
-    @BindView(R.id.activity_obd_selection_layout_available_devices_info)
     protected TextView mNewDevicesInfoTextView;
 
     // ArrayAdapter for the two different list views.
@@ -122,12 +114,19 @@ public class OBDSelectionFragment extends BaseInjectorFragment implements EasyPe
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle
             savedInstanceState) {
         super.onCreateView(inflater, container, savedInstanceState);
-        // infalte the content view of this activity.
-        View contentView = inflater.inflate(R.layout.activity_obd_selection_fragment,
-                container, false);
 
-        // Inject all annotated views.
-        ButterKnife.bind(this, contentView);
+        binding = ActivityObdSelectionFragmentBinding.inflate(inflater, container, false);
+        final View view = binding.getRoot();
+
+        mContentView = binding.activityObdSelectionLayoutContent;
+        mPairedDevicesTextView = binding.activityObdSelectionLayoutPairedDevicesText;
+        mPairedDevicesListView = binding.activityObdSelectionLayoutPairedDevicesList;
+        mNewDevicesListView = binding.activityObdSelectionLayoutAvailableDevicesList;
+        mProgressBar = binding.activityObdSelectionLayoutSearchDevicesProgressbar;
+        mRescanImageView = binding.activityObdSelectionLayoutRescanBluetooth;
+        mPairedDevicesInfoTextView = binding.activityObdSelectionLayoutPairedDevicesInfo;
+
+        mRescanImageView.setOnClickListener(v -> rediscover());
 
         // Setup the listviews, its adapters, and its onClick listener.
         setupListViews();
@@ -136,7 +135,7 @@ public class OBDSelectionFragment extends BaseInjectorFragment implements EasyPe
         //        setDynamicListHeight(mNewDevicesListView);
         //        setDynamicListHeight(mPairedDevicesListView);
 
-        return contentView;
+        return view;
     }
 
     @Override
@@ -147,11 +146,12 @@ public class OBDSelectionFragment extends BaseInjectorFragment implements EasyPe
 
     @Override
     public void onDestroy() {
+        super.onDestroy();
+        binding = null;
         if (mBTDiscoverySubscription != null && !mBTDiscoverySubscription.isDisposed()) {
             mBTDiscoverySubscription.dispose();
         }
         mNewDevicesListView.setOnItemClickListener(null);
-        super.onDestroy();
     }
 
     @Subscribe
@@ -162,7 +162,6 @@ public class OBDSelectionFragment extends BaseInjectorFragment implements EasyPe
         });
     }
 
-    @OnClick(R.id.activity_obd_selection_layout_rescan_bluetooth)
     protected void rediscover() {
         mBluetoothHandler.stopBluetoothDeviceDiscovery();
         checkAndRequestPermissions();
@@ -239,11 +238,11 @@ public class OBDSelectionFragment extends BaseInjectorFragment implements EasyPe
         // if location permissions are granted, start Bluetooth discovery.
         if (requestCode == BLUETOOTH_PERMISSIONS) {
             startBluetoothDiscovery();
-            
+
             // Check the GPS and Location permissions
             // before Starting the discovery of bluetooth devices.
             updateContentView();
-            
+
             showSnackbar(getString(R.string.location_permission_granted));
         }
     }
@@ -265,6 +264,7 @@ public class OBDSelectionFragment extends BaseInjectorFragment implements EasyPe
     /**
      * Initiates the discovery of other Bluetooth devices.
      */
+    @RequiresPermission(Manifest.permission.BLUETOOTH_CONNECT)
     private void startBluetoothDiscovery(){
         // If bluetooth is not enabled, skip the discovery and show a toast.
         if (!mBluetoothHandler.isBluetoothEnabled()) {
@@ -331,6 +331,7 @@ public class OBDSelectionFragment extends BaseInjectorFragment implements EasyPe
                     }
 
                     @Override
+                    @RequiresPermission(Manifest.permission.BLUETOOTH_CONNECT)
                     public void onNext(BluetoothDevice device) {
                         LOGGER.info(String.format(
                                 "Bluetooth device detected: [name=%s, address=%s]",
@@ -347,6 +348,7 @@ public class OBDSelectionFragment extends BaseInjectorFragment implements EasyPe
                 });
     }
 
+    @RequiresPermission(Manifest.permission.BLUETOOTH_CONNECT)
     private void setupListViews() {
         BluetoothDevice selectedBTDevice = mBluetoothHandler.getSelectedBluetoothDevice();
 
@@ -382,7 +384,7 @@ public class OBDSelectionFragment extends BaseInjectorFragment implements EasyPe
             final BluetoothDevice device = mNewDevicesArrayAdapter.getItem(position);
 
             // Create the Dialog
-            new MaterialAlertDialogBuilder(getActivity(), R.style.MaterialDialog)
+            new MaterialAlertDialogBuilder(requireActivity(), R.style.MaterialDialog)
                     .setTitle(R.string.bluetooth_pairing_preference_toolbar_title)
                     .setMessage(String.format(getString(
                             R.string.obd_selection_dialog_pairing_content_template), device.getName()))

--- a/org.envirocar.app/src/org/envirocar/app/views/others/HelpActivity.java
+++ b/org.envirocar.app/src/org/envirocar/app/views/others/HelpActivity.java
@@ -22,11 +22,10 @@ import android.os.Bundle;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.Toolbar;
 import android.view.MenuItem;
+import android.view.View;
 
 import org.envirocar.app.R;
-
-import butterknife.ButterKnife;
-import butterknife.BindView;
+import org.envirocar.app.databinding.ActivityHelpLayoutGeneralBinding;
 
 /**
  * TODO JavaDoc
@@ -35,17 +34,19 @@ import butterknife.BindView;
  */
 public class HelpActivity extends AppCompatActivity {
 
-    @BindView(R.id.activity_help_layout_general_toolbar)
+    private ActivityHelpLayoutGeneralBinding binding;
+
     protected Toolbar toolbar;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
-        setContentView(R.layout.activity_help_layout_general);
+        binding = ActivityHelpLayoutGeneralBinding.inflate(getLayoutInflater());
+        final View view = binding.getRoot();
+        setContentView(view);
 
-        // Inject views
-        ButterKnife.bind(this);
+        toolbar = binding.activityHelpLayoutGeneralToolbar;
 
         // Set Actionbar
         setSupportActionBar(toolbar);

--- a/org.envirocar.app/src/org/envirocar/app/views/others/OthersFragment.java
+++ b/org.envirocar.app/src/org/envirocar/app/views/others/OthersFragment.java
@@ -1,18 +1,18 @@
 /**
  * Copyright (C) 2013 - 2021 the enviroCar community
- *
+ * <p>
  * This file is part of the enviroCar app.
- *
+ * <p>
  * The enviroCar app is free software: you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as published
  * by the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- *
+ * <p>
  * The enviroCar app is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
  * Public License for more details.
- *
+ * <p>
  * You should have received a copy of the GNU General Public License along
  * with the enviroCar app. If not, see http://www.gnu.org/licenses/.
  */
@@ -41,6 +41,7 @@ import com.google.android.material.snackbar.Snackbar;
 import org.envirocar.app.BaseApplicationComponent;
 import org.envirocar.app.BuildConfig;
 import org.envirocar.app.R;
+import org.envirocar.app.databinding.FragmentOthersBinding;
 import org.envirocar.app.handler.TrackDAOHandler;
 import org.envirocar.app.handler.preferences.UserPreferenceHandler;
 import org.envirocar.app.injection.BaseInjectorFragment;
@@ -56,9 +57,6 @@ import java.util.concurrent.TimeUnit;
 
 import javax.inject.Inject;
 
-import butterknife.BindView;
-import butterknife.ButterKnife;
-import butterknife.OnClick;
 import io.reactivex.Scheduler;
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.observers.DisposableCompletableObserver;
@@ -70,14 +68,14 @@ import io.reactivex.schedulers.Schedulers;
 public class OthersFragment extends BaseInjectorFragment {
     private static final Logger LOGGER = Logger.getLogger(OthersFragment.class);
 
+    private FragmentOthersBinding binding;
+
     @Inject
     protected UserPreferenceHandler mUserManager;
     @Inject
     protected TrackDAOHandler mTrackDAOHandler;
 
-    @BindView(R.id.othersLogOut)
     protected LinearLayout othersLogOut;
-    @BindView(R.id.othersLogOutDivider)
     protected View othersLogOutDivider;
 
     private Scheduler.Worker mMainThreadWorker = AndroidSchedulers.mainThread().createWorker();
@@ -88,9 +86,20 @@ public class OthersFragment extends BaseInjectorFragment {
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container,
                              Bundle savedInstanceState) {
-        View view = inflater.inflate(R.layout.fragment_others, container, false);
+        binding = FragmentOthersBinding.inflate(inflater, container, false);
+        final View view = binding.getRoot();
 
-        ButterKnife.bind(this, view);
+        othersLogOut = binding.othersLogOut;
+        othersLogOutDivider = binding.othersLogOutDivider;
+
+        binding.othersLogBook.setOnClickListener(v -> onLogBookClicked());
+        binding.othersSettings.setOnClickListener(v -> onSettingsClicked());
+        binding.othersHelp.setOnClickListener(v -> onHelpClicked());
+        binding.othersTou.setOnClickListener(v -> onTouClicked());
+        binding.othersReportIssue.setOnClickListener(v -> onReportIssueClicked());
+        binding.othersRateUs.setOnClickListener(v -> onRateUsClicked());
+        binding.othersLogOut.setOnClickListener(v -> onLogOutClicked());
+        binding.othersCloseEnviroCar.setOnClickListener(v -> onCloseEnviroCarClicked());
 
         if (mUserManager.isLoggedIn()) {
             othersLogOut.setVisibility(View.VISIBLE);
@@ -103,6 +112,11 @@ public class OthersFragment extends BaseInjectorFragment {
         return view;
     }
 
+    @Override
+    public void onDestroyView() {
+        super.onDestroyView();
+        binding = null;
+    }
 
     @Override
     protected void injectDependencies(BaseApplicationComponent baseApplicationComponent) {
@@ -110,42 +124,36 @@ public class OthersFragment extends BaseInjectorFragment {
     }
 
 
-    @OnClick(R.id.othersLogBook)
     protected void onLogBookClicked() {
         Intent intent = new Intent(getActivity(), LogbookActivity.class);
         startActivity(intent);
     }
 
-    @OnClick(R.id.othersSettings)
     protected void onSettingsClicked() {
         Intent intent = new Intent(getActivity(), SettingsActivity.class);
         startActivity(intent);
     }
 
-    @OnClick(R.id.othersHelp)
     protected void onHelpClicked() {
         Intent intent = new Intent(getActivity(), HelpActivity.class);
         startActivity(intent);
     }
 
-    @OnClick(R.id.othersTou)
     protected void onTouClicked() {
         Intent intent = new Intent(getActivity(), TermsOfUseActivity.class);
         startActivity(intent);
     }
 
-    @OnClick(R.id.othersReportIssue)
     protected void onReportIssueClicked() {
 //        if (checkPermissions()) {
-            //access granted
-            Intent intent = new Intent(getActivity(), SendLogFileActivity.class);
-            startActivity(intent);
+        //access granted
+        Intent intent = new Intent(getActivity(), SendLogFileActivity.class);
+        startActivity(intent);
 //        } else {
 //            requestPermissions();
 //        }
     }
 
-    @OnClick(R.id.othersRateUs)
     protected void onRateUsClicked() {
         final String appPackageName = "org.envirocar.app"; // getPackageName() from Context or Activity object
         try {
@@ -155,7 +163,6 @@ public class OthersFragment extends BaseInjectorFragment {
         }
     }
 
-    @OnClick(R.id.othersLogOut)
     protected void onLogOutClicked() {
         // show dialog
         new MaterialAlertDialogBuilder(getActivity(), R.style.MaterialDialog)
@@ -164,11 +171,10 @@ public class OthersFragment extends BaseInjectorFragment {
                 .setIcon(R.drawable.ic_logout_white_24dp)
                 .setPositiveButton(R.string.menu_logout_envirocar_positive,
                         (dialog, which) -> mUserManager.logOut().subscribe(logOut()))
-                .setNegativeButton(R.string.menu_logout_envirocar_negative,null)
+                .setNegativeButton(R.string.menu_logout_envirocar_negative, null)
                 .show();
     }
 
-    @OnClick(R.id.othersCloseEnviroCar)
     protected void onCloseEnviroCarClicked() {
         // show closing dialog
         new MaterialAlertDialogBuilder(getActivity(), R.style.MaterialDialog)
@@ -177,7 +183,7 @@ public class OthersFragment extends BaseInjectorFragment {
                 .setIcon(R.drawable.ic_others_close_24)
                 .setPositiveButton(R.string.menu_close_envirocar_positive,
                         (dialog, which) -> shutdownEnviroCar())
-                .setNegativeButton(R.string.menu_logout_envirocar_negative,null)
+                .setNegativeButton(R.string.menu_logout_envirocar_negative, null)
                 .show();
     }
 
@@ -204,7 +210,7 @@ public class OthersFragment extends BaseInjectorFragment {
                     .setTitle(R.string.request_storage_permission_title)
                     .setMessage(R.string.permission_rationale_file)
                     .setIcon(R.drawable.others_settings)
-                    .setPositiveButton(R.string.ok,(dialog, which) -> {
+                    .setPositiveButton(R.string.ok, (dialog, which) -> {
                         // Request permission
                         ActivityCompat.requestPermissions(getActivity(),
                                 new String[]{Manifest.permission.WRITE_EXTERNAL_STORAGE},
@@ -276,9 +282,9 @@ public class OthersFragment extends BaseInjectorFragment {
     private void showSnackbar(final int mainTextStringId, final int actionStringId,
                               View.OnClickListener listener) {
         Snackbar.make(
-                getActivity().findViewById(R.id.navigation),
-                getString(mainTextStringId),
-                Snackbar.LENGTH_INDEFINITE)
+                        getActivity().findViewById(R.id.navigation),
+                        getString(mainTextStringId),
+                        Snackbar.LENGTH_INDEFINITE)
                 .setAction(getString(actionStringId), listener).show();
     }
 
@@ -295,20 +301,22 @@ public class OthersFragment extends BaseInjectorFragment {
 
     private DisposableCompletableObserver logOut() {
         return new DisposableCompletableObserver() {
-            User tempUser=null;
-            MaterialDialog dialog=null;
+            User tempUser = null;
+            MaterialDialog dialog = null;
+
             @Override
             public void onStart() {
 
                 this.tempUser = mUserManager.getUser();
 
-                this.dialog=new MaterialDialog.Builder(getContext())
+                this.dialog = new MaterialDialog.Builder(getContext())
                         .title(R.string.activity_login_logout_progress_dialog_title)
                         .content(R.string.activity_login_logout_progress_dialog_content)
                         .progress(true, 0)
                         .cancelable(false)
                         .show();
             }
+
             @Override
             public void onComplete() {
                 Snackbar.make(getActivity().findViewById(R.id.navigation),

--- a/org.envirocar.app/src/org/envirocar/app/views/others/SendLogFileActivity.java
+++ b/org.envirocar.app/src/org/envirocar/app/views/others/SendLogFileActivity.java
@@ -43,6 +43,7 @@ import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 
 import org.envirocar.app.BaseApplicationComponent;
 import org.envirocar.app.R;
+import org.envirocar.app.databinding.SendLogLayoutNewBinding;
 import org.envirocar.app.handler.ApplicationSettings;
 import org.envirocar.app.handler.BluetoothHandler;
 import org.envirocar.app.handler.preferences.CarPreferenceHandler;
@@ -68,12 +69,6 @@ import java.util.Locale;
 
 import javax.inject.Inject;
 
-import butterknife.BindArray;
-import butterknife.BindView;
-import butterknife.ButterKnife;
-import butterknife.OnClick;
-import butterknife.OnFocusChange;
-
 /**
  * An activity for reporting issues.
  *
@@ -89,20 +84,15 @@ public class SendLogFileActivity extends BaseInjectorActivity {
     private static final String OTHER_DETAILS_PREFIX = "extra-info";
     private static final String EXTENSION = ".zip";
 
-    @BindView(R.id.envirocar_toolbar)
+    private SendLogLayoutNewBinding binding;
+
     protected Toolbar toolbar;
-    @BindView(R.id.report_issue_time_since_crash)
     protected EditText whenField;
-    @BindView(R.id.report_issue_desc)
     protected EditText comments;
-    @BindView(R.id.report_issue_submit)
     protected View submitIssue;
-    @BindView(R.id.report_issue_checkbox_list)
     protected ListView checkBoxListView;
 
-    @BindArray(R.array.report_issue_subject_header)
     protected String[] subjectHeaders;
-    @BindArray(R.array.report_issue_subject_tags)
     protected String[] subjectTags;
 
     @Inject
@@ -121,8 +111,21 @@ public class SendLogFileActivity extends BaseInjectorActivity {
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        setContentView(R.layout.send_log_layout_new);
-        ButterKnife.bind(this);
+        binding = SendLogLayoutNewBinding.inflate(getLayoutInflater());
+        setContentView(binding.getRoot());
+
+        toolbar = binding.envirocarToolbar.envirocarToolbar;
+        whenField = binding.reportIssueTimeSinceCrash;
+        comments = binding.reportIssueDesc;
+        submitIssue = binding.reportIssueSubmit;
+        checkBoxListView = binding.reportIssueCheckboxList;
+
+        submitIssue.setOnClickListener(this::onClickSubmitButton);
+        whenField.setOnFocusChangeListener(this::onWhenFieldFocusChange);
+        comments.setOnFocusChangeListener(this::onCommentsFocusChange);
+
+        subjectHeaders = getResources().getStringArray(R.array.report_issue_subject_header);
+        subjectTags = getResources().getStringArray(R.array.report_issue_subject_tags);
 
         setSupportActionBar(toolbar);
         getSupportActionBar().setDisplayHomeAsUpEnabled(true);
@@ -137,7 +140,6 @@ public class SendLogFileActivity extends BaseInjectorActivity {
         }
     }
 
-    @OnClick(R.id.report_issue_submit)
     public void onClickSubmitButton(View v) {
         try {
             final File tmpBundle = createReportBundle();
@@ -151,14 +153,12 @@ public class SendLogFileActivity extends BaseInjectorActivity {
         }
     }
 
-    @OnFocusChange(R.id.report_issue_time_since_crash)
     public void onWhenFieldFocusChange(View v, boolean hasFocus) {
         if (!hasFocus) {
             hideKeyboard(v);
         }
     }
 
-    @OnFocusChange(R.id.report_issue_desc)
     public void onCommentsFocusChange(View v, boolean hasFocus) {
         if (!hasFocus) {
             hideKeyboard(v);

--- a/org.envirocar.app/src/org/envirocar/app/views/others/UserStatisticsAdapter.java
+++ b/org.envirocar.app/src/org/envirocar/app/views/others/UserStatisticsAdapter.java
@@ -25,14 +25,11 @@ import android.view.ViewGroup;
 import android.widget.ArrayAdapter;
 import android.widget.TextView;
 
-import org.envirocar.app.R;
+import org.envirocar.app.databinding.ActivityAccountStatisticListEntryBinding;
 import org.envirocar.core.entity.Phenomenon;
 
 import java.text.DecimalFormat;
 import java.util.List;
-
-import butterknife.ButterKnife;
-import butterknife.BindView;
 
 /**
  * @author dewall
@@ -59,16 +56,10 @@ public class UserStatisticsAdapter extends ArrayAdapter<Phenomenon> {
 
         ViewHolder viewHolder = null;
         if (convertView == null) {
-            LayoutInflater inflater = (LayoutInflater) getContext()
-                    .getSystemService(Context.LAYOUT_INFLATER_SERVICE);
-            convertView = inflater.inflate(
-                    R.layout.activity_account_statistic_list_entry, parent, false);
-
-            // Create a new viewholder and inject the sub-views of the newly inflated convertView.
-            viewHolder = new ViewHolder();
-            ButterKnife.bind(viewHolder, convertView);
-
-            // Set the viewHolder as tag on the convertView.
+            final LayoutInflater inflater = LayoutInflater.from(getContext());
+            final ActivityAccountStatisticListEntryBinding binding = ActivityAccountStatisticListEntryBinding.inflate(inflater, parent, false);
+            convertView = binding.getRoot();
+            viewHolder = new ViewHolder(binding);
             convertView.setTag(viewHolder);
         } else {
             viewHolder = (ViewHolder) convertView.getTag();
@@ -86,13 +77,16 @@ public class UserStatisticsAdapter extends ArrayAdapter<Phenomenon> {
     }
 
     static final class ViewHolder {
-        @BindView(R.id.activity_account_statistics_list_entry_phenomenon)
         TextView mPhenomenonTextView;
-        @BindView(R.id.activity_account_statistics_list_entry_avg_value)
         TextView mAvgValue;
-        @BindView(R.id.activity_account_statistics_list_entry_max_value)
         TextView mMaxValue;
-        @BindView(R.id.activity_account_statistics_list_entry_min_value)
         TextView mMinValue;
+
+        ViewHolder(ActivityAccountStatisticListEntryBinding binding) {
+            mPhenomenonTextView = binding.activityAccountStatisticsListEntryPhenomenon;
+            mAvgValue = binding.activityAccountStatisticsListEntryAvgValue;
+            mMaxValue = binding.activityAccountStatisticsListEntryMaxValue;
+            mMinValue = binding.activityAccountStatisticsListEntryMinValue;
+        }
     }
 }

--- a/org.envirocar.app/src/org/envirocar/app/views/preferences/BluetoothPairingPreference.java
+++ b/org.envirocar.app/src/org/envirocar/app/views/preferences/BluetoothPairingPreference.java
@@ -22,10 +22,8 @@ import android.app.AlertDialog;
 import android.bluetooth.BluetoothDevice;
 import android.content.Context;
 import android.content.DialogInterface;
-import android.content.res.Resources;
 import android.preference.DialogPreference;
 import android.util.AttributeSet;
-import android.view.LayoutInflater;
 import android.view.View;
 import android.widget.LinearLayout;
 import android.widget.ListView;
@@ -39,9 +37,9 @@ import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import com.squareup.otto.Bus;
 import com.squareup.otto.Subscribe;
 
+import org.envirocar.app.BaseApplication;
 import org.envirocar.app.R;
 import org.envirocar.app.handler.BluetoothHandler;
-import org.envirocar.app.BaseApplication;
 import org.envirocar.app.views.preferences.bluetooth.BluetoothDeviceListAdapter;
 import org.envirocar.core.events.bluetooth.BluetoothPairingChangedEvent;
 import org.envirocar.core.events.bluetooth.BluetoothStateChangedEvent;
@@ -51,8 +49,6 @@ import java.util.Set;
 
 import javax.inject.Inject;
 
-import butterknife.BindView;
-import butterknife.ButterKnife;
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.observers.DisposableObserver;
@@ -65,21 +61,15 @@ public class BluetoothPairingPreference extends DialogPreference {
     private static final Logger LOGGER = Logger.getLogger(BluetoothPairingPreference.class);
 
     // Views for the already paired devices.
-    @BindView(R.id.bluetooth_pairing_preference_paired_devices_text)
     public TextView mPairedDevicesTextView;
-    @BindView(R.id.bluetooth_pairing_preference_paired_devices_list)
     public ListView mPairedDevicesListView;
 
     // Views for the newly discovered devices.
-    @BindView(R.id.bluetooth_pairing_preference_available_devices_text)
     public TextView mNewDevicesTextView;
-    @BindView(R.id.bluetooth_pairing_preference_available_devices_list)
     public ListView mNewDevicesListView;
 
     // No device found.
-    @BindView(R.id.bluetooth_pairing_preference_available_devices_info)
     public TextView mNewDevicesInfoTextView;
-    @BindView(R.id.bluetooth_pairing_preference_search_devices_progressbar)
     public ProgressBar mProgressBar;
 
     // Injected variables.
@@ -89,7 +79,6 @@ public class BluetoothPairingPreference extends DialogPreference {
     protected BluetoothHandler mBluetoothHandler;
 
     // Main parent view for the content.
-    @BindView(R.id.bluetooth_pairing_preference_content)
     protected LinearLayout mContentView;
 
     // ArrayAdapter for the two different list views.
@@ -121,8 +110,13 @@ public class BluetoothPairingPreference extends DialogPreference {
     protected void onBindDialogView(final View view) {
         super.onBindDialogView(view);
 
-        // Inject all views.
-        ButterKnife.bind(this, view);
+        mPairedDevicesTextView = view.findViewById(R.id.bluetooth_pairing_preference_paired_devices_text);
+        mPairedDevicesListView = view.findViewById(R.id.bluetooth_pairing_preference_paired_devices_list);
+        mNewDevicesTextView = view.findViewById(R.id.bluetooth_pairing_preference_available_devices_text);
+        mNewDevicesListView = view.findViewById(R.id.bluetooth_pairing_preference_available_devices_list);
+        mNewDevicesInfoTextView = view.findViewById(R.id.bluetooth_pairing_preference_available_devices_info);
+        mProgressBar = view.findViewById(R.id.bluetooth_pairing_preference_search_devices_progressbar);
+        mContentView = view.findViewById(R.id.bluetooth_pairing_preference_content);
 
         // Initialize the array adapter for both list views
         mNewDevicesArrayAdapter = new BluetoothDeviceListAdapter(getContext(),
@@ -142,12 +136,9 @@ public class BluetoothPairingPreference extends DialogPreference {
         toolbar.setTitleTextColor(getContext().getResources().getColor(R.color
                 .white_cario));
         toolbar.setOnMenuItemClickListener(item -> {
-            switch (item.getItemId()) {
-                case R.id.menu_action_search_bluetooth_devices:
-                    startBluetoothDiscovery();
-                    return true;
-                default:
-                    break;
+            if (item.getItemId() == R.id.menu_action_search_bluetooth_devices) {
+                startBluetoothDiscovery();
+                return true;
             }
             return false;
         });

--- a/org.envirocar.app/src/org/envirocar/app/views/recordingscreen/RecordingScreenActivity.java
+++ b/org.envirocar.app/src/org/envirocar/app/views/recordingscreen/RecordingScreenActivity.java
@@ -37,6 +37,7 @@ import com.squareup.otto.Subscribe;
 
 import org.envirocar.app.BaseApplicationComponent;
 import org.envirocar.app.R;
+import org.envirocar.app.databinding.ActivityRecordingScreenBinding;
 import org.envirocar.app.events.AvrgSpeedUpdateEvent;
 import org.envirocar.app.events.DistanceValueUpdateEvent;
 import org.envirocar.app.events.DrivingDetectedEvent;
@@ -59,9 +60,6 @@ import java.text.DecimalFormat;
 
 import javax.inject.Inject;
 
-import butterknife.BindView;
-import butterknife.ButterKnife;
-import butterknife.OnClick;
 import io.reactivex.Observable;
 import io.reactivex.android.schedulers.AndroidSchedulers;
 
@@ -83,6 +81,8 @@ public class RecordingScreenActivity extends BaseInjectorActivity {
         context.startActivity(new Intent(context, RecordingScreenActivity.class));
     }
 
+    private ActivityRecordingScreenBinding binding;
+
     // Injected dependencies
     @Inject
     protected TrackMapFragment trackMapFragment;
@@ -92,27 +92,16 @@ public class RecordingScreenActivity extends BaseInjectorActivity {
     protected TrackRecordingHandler trackRecordingHandler;
 
     // Injected views
-    @BindView(R.id.activity_recscreen_trackdetails_gps)
     protected ImageView gpsImage;
-    @BindView(R.id.activity_recscreen_trackdetails_bluetooth)
     protected ImageView bluetoothImage;
-    @BindView(R.id.activity_recscreen_trackdetails_bluetooth_text)
     protected TextView bluetoothText;
-    @BindView(R.id.activity_recscreen_trackdetails_timer)
     protected Chronometer timerText;
-    @BindView(R.id.activity_recscreen_trackdetails_distance)
     protected TextView distanceText;
-    @BindView(R.id.activity_recscreen_trackdetails_speed)
     protected TextView speedText;
-    @BindView(R.id.activity_recscreen_trackdetails_container)
     protected LinearLayout trackDetailsContainer;
-    @BindView(R.id.activity_recscreen_trackmap_container)
     protected LinearLayout mapContainer;
-    @BindView(R.id.activity_recscreen_tempomat_container)
     protected LinearLayout tempomatContainer;
-    @BindView(R.id.activity_recscreen_stopbutton)
     protected LinearLayout stopTrackRecordingButton;
-    @BindView(R.id.activity_recscreen_track_upload_status)
     protected LinearLayout trackUploadStatus;
 
     // state variables
@@ -129,16 +118,31 @@ public class RecordingScreenActivity extends BaseInjectorActivity {
     protected void onCreate(Bundle savedInstanceState) {
         LOG.info("Creating RecordingScreenActivity");
         super.onCreate(savedInstanceState);
-        setContentView(R.layout.activity_recording_screen);
+
+        binding = ActivityRecordingScreenBinding.inflate(getLayoutInflater());
+        final View view = binding.getRoot();
+        setContentView(view);
+
+        gpsImage = binding.activityRecscreenTrackdetailsGps;
+        bluetoothImage = binding.activityRecscreenTrackdetailsBluetooth;
+        bluetoothText = binding.activityRecscreenTrackdetailsBluetoothText;
+        timerText = binding.activityRecscreenTrackdetailsTimer;
+        distanceText = binding.activityRecscreenTrackdetailsDistance;
+        speedText = binding.activityRecscreenTrackdetailsSpeed;
+        trackDetailsContainer = binding.activityRecscreenTrackdetailsContainer;
+        mapContainer = binding.activityRecscreenTrackmapContainer;
+        tempomatContainer = binding.activityRecscreenTempomatContainer;
+        stopTrackRecordingButton = binding.activityRecscreenStopbutton;
+        trackUploadStatus = binding.activityRecscreenTrackUploadStatus;
+
+        binding.activityRecscreenSwitchbutton.setOnClickListener(v -> onSwitchViewsButtonClicked());
+        binding.activityRecscreenStopbutton.setOnClickListener(v -> onStopButtonClicked());
 
         //if the track recording service is stopped then finish this activity and goback to bottombar main activity
         if (RecordingService.RECORDING_STATE == RecordingState.RECORDING_STOPPED) {
             startActivity(new Intent(RecordingScreenActivity.this, BaseMainActivity.class));
             finish();
         }
-
-        // Inject all dashboard-related views.
-        ButterKnife.bind(this);
 
         this.recordingType = ApplicationSettings.getSelectedRecordingTypeObservable(this).blockingFirst();
         if (recordingType.equals(RecordingType.ACTIVITY_RECOGNITION_BASED)) {
@@ -198,7 +202,6 @@ public class RecordingScreenActivity extends BaseInjectorActivity {
         super.onDestroy();
     }
 
-    @OnClick(R.id.activity_recscreen_switchbutton)
     protected void onSwitchViewsButtonClicked() {
         LOG.info("Switch views button clicked");
         Observable.just(true)
@@ -208,7 +211,6 @@ public class RecordingScreenActivity extends BaseInjectorActivity {
                 .subscribe();
     }
 
-    @OnClick(R.id.activity_recscreen_stopbutton)
     protected void onStopButtonClicked() {
         LOG.info("Stop button has been clicked. Showing dialog to request confirmation");
 

--- a/org.envirocar.app/src/org/envirocar/app/views/recordingscreen/TempomatFragment.java
+++ b/org.envirocar.app/src/org/envirocar/app/views/recordingscreen/TempomatFragment.java
@@ -19,24 +19,22 @@
 package org.envirocar.app.views.recordingscreen;
 
 import android.os.Bundle;
-import androidx.annotation.Nullable;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
+import androidx.annotation.Nullable;
+
 import com.squareup.otto.Subscribe;
 
 import org.envirocar.app.BaseApplicationComponent;
-import org.envirocar.app.injection.components.MainActivityComponent;
-import org.envirocar.app.injection.modules.MainActivityModule;
-import org.envirocar.app.R;
+import org.envirocar.app.databinding.FragmentTempomatViewBinding;
 import org.envirocar.app.events.GPSSpeedChangeEvent;
 import org.envirocar.app.injection.BaseInjectorFragment;
+import org.envirocar.app.injection.components.MainActivityComponent;
+import org.envirocar.app.injection.modules.MainActivityModule;
 import org.envirocar.core.logging.Logger;
 import org.envirocar.obd.events.SpeedUpdateEvent;
-
-import butterknife.BindView;
-import butterknife.ButterKnife;
 
 /**
  * @author dewall
@@ -44,7 +42,8 @@ import butterknife.ButterKnife;
 public class TempomatFragment extends BaseInjectorFragment {
     private static final Logger LOG = Logger.getLogger(TempomatFragment.class);
 
-    @BindView(R.id.fragment_dashboard_tempomat_view)
+    private FragmentTempomatViewBinding binding;
+
     protected Tempomat mTempomatView;
 
     @Nullable
@@ -53,14 +52,19 @@ public class TempomatFragment extends BaseInjectorFragment {
             savedInstanceState) {
         LOG.info("onCreateView()");
 
-        // First inflate the general dashboard view.
-        View contentView = inflater.inflate(R.layout.fragment_tempomat_view, container, false);
+        binding = FragmentTempomatViewBinding.inflate(inflater, container, false);
+        final View view = binding.getRoot();
 
-        // Inject all dashboard-related views.
-        ButterKnife.bind(this, contentView);
+        mTempomatView = binding.fragmentDashboardTempomatView;
 
         // return the inflated content view.
-        return contentView;
+        return view;
+    }
+
+    @Override
+    public void onDestroyView() {
+        super.onDestroyView();
+        binding = null;
     }
 
     @Override

--- a/org.envirocar.app/src/org/envirocar/app/views/recordingscreen/TrackMapFragment.java
+++ b/org.envirocar.app/src/org/envirocar/app/views/recordingscreen/TrackMapFragment.java
@@ -20,11 +20,6 @@ package org.envirocar.app.views.recordingscreen;
 
 import android.graphics.Color;
 import android.os.Bundle;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import com.google.android.material.floatingactionbutton.FloatingActionButton;
-
 import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -33,6 +28,10 @@ import android.view.animation.Animation;
 import android.view.animation.AnimationUtils;
 import android.widget.Toast;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.google.android.material.floatingactionbutton.FloatingActionButton;
 import com.mapbox.android.core.location.LocationEngineRequest;
 import com.mapbox.android.core.permissions.PermissionsListener;
 import com.mapbox.android.core.permissions.PermissionsManager;
@@ -56,22 +55,18 @@ import com.mapbox.mapboxsdk.style.sources.GeoJsonSource;
 import com.squareup.otto.Subscribe;
 
 import org.envirocar.app.BaseApplicationComponent;
-import org.envirocar.app.injection.components.MainActivityComponent;
-import org.envirocar.app.injection.modules.MainActivityModule;
 import org.envirocar.app.R;
+import org.envirocar.app.databinding.FragmentTrackMapBinding;
 import org.envirocar.app.events.TrackPathOverlayEvent;
 import org.envirocar.app.injection.BaseInjectorFragment;
-import org.envirocar.app.views.obdselection.OBDSelectionFragment;
+import org.envirocar.app.injection.components.MainActivityComponent;
+import org.envirocar.app.injection.modules.MainActivityModule;
 import org.envirocar.app.views.trackdetails.MapLayer;
 import org.envirocar.core.logging.Logger;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import butterknife.BindView;
-import butterknife.ButterKnife;
-import butterknife.OnClick;
-import butterknife.OnTouch;
 import io.reactivex.Scheduler;
 import io.reactivex.android.schedulers.AndroidSchedulers;
 
@@ -81,13 +76,13 @@ import io.reactivex.android.schedulers.AndroidSchedulers;
 public class TrackMapFragment extends BaseInjectorFragment implements PermissionsListener {
     private static final Logger LOG = Logger.getLogger(TrackMapFragment.class);
 
+    private FragmentTrackMapBinding binding;
+
     private PermissionsManager permissionsManager;
     private MapboxMap mapboxMap;
     private Style mapStyle;
     private LocationComponent locationComponent;
-    @BindView(R.id.fragment_dashboard_frag_map_mapview)
     protected MapView mMapView;
-    @BindView(R.id.activity_map_follow_fab)
     protected FloatingActionButton mFollowFab;
 
     private MapLayer mPathOverlay;
@@ -104,11 +99,14 @@ public class TrackMapFragment extends BaseInjectorFragment implements Permission
             savedInstanceState) {
         LOG.info("onCreateView()");
 
-        // First inflate the general dashboard view.
-        View contentView = inflater.inflate(R.layout.fragment_track_map, container, false);
+        binding = FragmentTrackMapBinding.inflate(inflater, container, false);
+        final View view = binding.getRoot();
 
-        // Inject all dashboard-related views.
-        ButterKnife.bind(this, contentView);
+        mMapView = binding.fragmentDashboardFragMapMapview;
+        mFollowFab = binding.activityMapFollowFab;
+
+        mMapView.setOnTouchListener((v, event) -> onTouchMapView());
+        mFollowFab.setOnClickListener(v -> onClickFollowFab());
 
         // Init the map view
         mMapView.onCreate(savedInstanceState);
@@ -148,7 +146,13 @@ public class TrackMapFragment extends BaseInjectorFragment implements Permission
         mIsFollowingLocation = true;
         mFollowFab.setVisibility(View.INVISIBLE);
 
-        return contentView;
+        return view;
+    }
+
+    @Override
+    public void onDestroyView() {
+        super.onDestroyView();
+        binding = null;
     }
 
     private void setCameraTrackingMode(@CameraMode.Mode int mode) {
@@ -179,7 +183,6 @@ public class TrackMapFragment extends BaseInjectorFragment implements Permission
         });
     }
 
-    @OnTouch(R.id.fragment_dashboard_frag_map_mapview)
     protected boolean onTouchMapView() {
         if (mIsFollowingLocation) {
             setCameraTrackingMode(CameraMode.NONE);
@@ -191,7 +194,6 @@ public class TrackMapFragment extends BaseInjectorFragment implements Permission
         return false;
     }
 
-    @OnClick(R.id.activity_map_follow_fab)
     protected void onClickFollowFab() {
         if (!mIsFollowingLocation) {
             setCameraTrackingMode(CameraMode.TRACKING_GPS);

--- a/org.envirocar.app/src/org/envirocar/app/views/settings/custom/SamplingRatePreference.java
+++ b/org.envirocar.app/src/org/envirocar/app/views/settings/custom/SamplingRatePreference.java
@@ -32,9 +32,6 @@ import org.envirocar.app.R;
 import org.envirocar.app.handler.ApplicationSettings;
 import org.envirocar.core.logging.Logger;
 
-import butterknife.BindView;
-import butterknife.ButterKnife;
-
 /**
  * @author dewall
  */
@@ -77,9 +74,7 @@ public class SamplingRatePreference extends DialogPreference implements TimePick
             return fragment;
         }
 
-        @BindView(R.id.preference_sampling_rate_dialog_text)
         protected TextView textView;
-        @BindView(R.id.preference_sampling_rate_dialog_picker)
         protected NumberPicker numberPicker;
 
 
@@ -87,8 +82,7 @@ public class SamplingRatePreference extends DialogPreference implements TimePick
         protected void onBindDialogView(View view) {
             super.onBindDialogView(view);
 
-            // inject views
-            ButterKnife.bind(this, view);
+
 
             // set min/max values
             this.numberPicker.setMinValue(MIN_VALUE);

--- a/org.envirocar.app/src/org/envirocar/app/views/settings/custom/TimePickerPreferenceDialog.java
+++ b/org.envirocar.app/src/org/envirocar/app/views/settings/custom/TimePickerPreferenceDialog.java
@@ -33,9 +33,6 @@ import org.envirocar.app.handler.ApplicationSettings;
 
 import java.lang.reflect.Field;
 
-import butterknife.BindView;
-import butterknife.ButterKnife;
-
 public class TimePickerPreferenceDialog extends PreferenceDialogFragmentCompat {
 
     public interface TimePickerPreference {
@@ -70,19 +67,17 @@ public class TimePickerPreferenceDialog extends PreferenceDialogFragmentCompat {
     private int currentMinutes;
 
 
-    @BindView(R.id.preference_timepicker_text)
     protected TextView text;
-    @BindView(R.id.preference_timepicker_minutes_picker)
     protected NumberPicker minutePicker;
-    @BindView(R.id.preference_timepicker_seconds_picker)
     protected NumberPicker secondsPicker;
 
     @Override
     protected void onBindDialogView(View view) {
         super.onBindDialogView(view);
 
-        // inject views
-        ButterKnife.bind(this, view);
+        text = view.findViewById(R.id.preference_timepicker_text);
+        minutePicker = view.findViewById(R.id.preference_timepicker_minutes_picker);
+        secondsPicker = view.findViewById(R.id.preference_timepicker_seconds_picker);
 
         // Set the textview text
         this.text.setText(R.string.pref_bt_discovery_interval_explanation);

--- a/org.envirocar.app/src/org/envirocar/app/views/trackdetails/MapExpandedActivity.java
+++ b/org.envirocar.app/src/org/envirocar/app/views/trackdetails/MapExpandedActivity.java
@@ -21,7 +21,6 @@ package org.envirocar.app.views.trackdetails;
 
 import android.app.Activity;
 import android.app.AlertDialog;
-import android.content.DialogInterface;
 import android.content.Intent;
 import android.graphics.BitmapFactory;
 import android.os.Bundle;
@@ -50,6 +49,7 @@ import com.mapbox.mapboxsdk.style.layers.SymbolLayer;
 import com.mapbox.mapboxsdk.style.sources.GeoJsonSource;
 
 import org.envirocar.app.R;
+import org.envirocar.app.databinding.ActivityMapExpandedBinding;
 import org.envirocar.app.injection.BaseInjectorActivity;
 import org.envirocar.app.BaseApplicationComponent;
 import org.envirocar.core.entity.Measurement;
@@ -63,10 +63,6 @@ import java.util.List;
 
 import javax.inject.Inject;
 
-import butterknife.BindView;
-import butterknife.ButterKnife;
-import butterknife.OnClick;
-import butterknife.OnTouch;
 import io.reactivex.schedulers.Schedulers;
 
 import static android.view.View.GONE;
@@ -78,30 +74,21 @@ public class MapExpandedActivity extends BaseInjectorActivity {
     private static final String EXTRA_TRACKID = "org.envirocar.app.extraTrackID";
     private static final String EXTRA_TITLE = "org.envirocar.app.extraTitle";
 
+    private ActivityMapExpandedBinding binding;
+
     @Inject
     protected EnviroCarDB enviroCarDB;
 
-    @BindView(R.id.activity_map_follow_fab)
     protected FloatingActionButton mCentreFab;
-    @BindView(R.id.activity_map_visualise_fab)
     protected FloatingActionButton mVisualiseFab;
-    @BindView(R.id.activity_track_details_expanded_map_cancel)
     protected ImageView mMapViewExpandedCancel;
-    @BindView(R.id.activity_track_details_expanded_map)
     protected MapView mMapViewExpanded;
-    @BindView(R.id.activity_track_details_expanded_map_container)
     protected ConstraintLayout mMapViewExpandedContainer;
-    @BindView(R.id.legendCard)
     protected CardView legendCard;
-    @BindView(R.id.legend)
     protected ImageView legend;
-    @BindView(R.id.legend_start)
     protected TextView legendStart;
-    @BindView(R.id.legend_mid)
     protected TextView legendMid;
-    @BindView(R.id.legend_end)
     protected TextView legendEnd;
-    @BindView(R.id.legend_unit)
     protected TextView legendName;
 
     protected MapboxMap mapboxMapExpanded;
@@ -126,9 +113,27 @@ public class MapExpandedActivity extends BaseInjectorActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        setContentView(R.layout.activity_map_expanded);
-        // Inject all annotated views.
-        ButterKnife.bind(this);
+
+        binding = ActivityMapExpandedBinding.inflate(getLayoutInflater());
+        final View view = binding.getRoot();
+        setContentView(view);
+
+        mCentreFab = binding.activityMapFollowFab;
+        mVisualiseFab = binding.activityMapVisualiseFab;
+        mMapViewExpandedCancel = binding.activityTrackDetailsExpandedMapCancel;
+        mMapViewExpanded = binding.activityTrackDetailsExpandedMap;
+        mMapViewExpandedContainer = binding.activityTrackDetailsExpandedMapContainer;
+        legendCard = binding.legendCard;
+        legend = binding.legend;
+        legendStart = binding.legendStart;
+        legendMid = binding.legendMid;
+        legendEnd = binding.legendEnd;
+        legendName = binding.legendUnit;
+
+        mMapViewExpanded.setOnTouchListener((v, event) -> onTouchMapView());
+        mCentreFab.setOnClickListener(v -> onClickFollowFab());
+        mVisualiseFab.setOnClickListener(v -> onClickVisualiseFab());
+
         mMapViewExpanded.onCreate(savedInstanceState);
 
         // Get the track to show.
@@ -154,7 +159,6 @@ public class MapExpandedActivity extends BaseInjectorActivity {
         mMapViewExpandedCancel.setOnClickListener(v -> finish());
     }
 
-    @OnTouch(R.id.activity_track_details_expanded_map)
     protected boolean onTouchMapView() {
         if (mIsCentredOnTrack) {
             mIsCentredOnTrack = false;
@@ -164,7 +168,6 @@ public class MapExpandedActivity extends BaseInjectorActivity {
         return false;
     }
 
-    @OnClick(R.id.activity_map_follow_fab)
     protected void onClickFollowFab() {
         final LatLngBounds viewBbox = trackMapOverlay.getViewBoundingBox();
         if (!mIsCentredOnTrack) {
@@ -175,7 +178,6 @@ public class MapExpandedActivity extends BaseInjectorActivity {
         }
     }
 
-    @OnClick(R.id.activity_map_visualise_fab)
     protected void onClickVisualiseFab() {
         LOG.info("onClickVisualiseFab");
         AlertDialog.Builder b = new AlertDialog.Builder(this);

--- a/org.envirocar.app/src/org/envirocar/app/views/trackdetails/TrackDetailsActivity.java
+++ b/org.envirocar.app/src/org/envirocar/app/views/trackdetails/TrackDetailsActivity.java
@@ -39,8 +39,6 @@ import androidx.core.widget.NestedScrollView;
 import com.google.android.material.appbar.AppBarLayout;
 import com.google.android.material.appbar.CollapsingToolbarLayout;
 import com.google.android.material.floatingactionbutton.FloatingActionButton;
-import com.google.android.material.snackbar.BaseTransientBottomBar;
-import com.google.android.material.snackbar.Snackbar;
 import com.mapbox.geojson.Feature;
 import com.mapbox.geojson.Point;
 import com.mapbox.mapboxsdk.camera.CameraUpdateFactory;
@@ -54,6 +52,7 @@ import com.mapbox.mapboxsdk.style.sources.GeoJsonSource;
 
 import org.envirocar.app.BaseApplicationComponent;
 import org.envirocar.app.R;
+import org.envirocar.app.databinding.ActivityTrackDetailsLayoutBinding;
 import org.envirocar.app.handler.ApplicationSettings;
 import org.envirocar.app.injection.BaseInjectorActivity;
 import org.envirocar.core.EnviroCarDB;
@@ -78,8 +77,6 @@ import java.util.TimeZone;
 
 import javax.inject.Inject;
 
-import butterknife.BindView;
-import butterknife.ButterKnife;
 import io.reactivex.schedulers.Schedulers;
 
 
@@ -107,58 +104,35 @@ public class TrackDetailsActivity extends BaseInjectorActivity {
         UTC_DATE_FORMATTER.setTimeZone(TimeZone.getTimeZone("UTC"));
     }
 
+    private ActivityTrackDetailsLayoutBinding binding;
+
     @Inject
     protected EnviroCarDB mEnvirocarDB;
 
-    @BindView(R.id.activity_track_details_fab)
     protected FloatingActionButton mFAB;
-    @BindView(R.id.activity_track_details_header_map)
     protected MapView mMapView;
-    @BindView(R.id.activity_track_details_header_toolbar)
     protected Toolbar mToolbar;
-    @BindView(R.id.activity_track_details_attr_description_value)
     protected TextView mDescriptionText;
-    @BindView(R.id.track_details_attributes_header_duration)
     protected TextView mDurationText;
-    @BindView(R.id.track_details_attributes_header_distance)
     protected TextView mDistanceText;
-    @BindView(R.id.activity_track_details_attr_begin_value)
     protected TextView mBeginText;
-    @BindView(R.id.activity_track_details_attr_end_value)
     protected TextView mEndText;
-    @BindView(R.id.activity_track_details_attr_car_value)
     protected TextView mCarText;
-    @BindView(R.id.activity_track_details_attr_emission_text)
     protected TextView mEmissionKey;
-    @BindView(R.id.activity_track_details_attr_emission_value)
     protected TextView mEmissionText;
-    @BindView(R.id.activity_track_details_attr_consumption_text)
     protected TextView mConsumptionKey;
-    @BindView(R.id.activity_track_details_attr_consumption_value)
     protected TextView mConsumptionText;
-    @BindView(R.id.activity_track_details_appbar_layout)
     protected AppBarLayout mAppBarLayout;
-    @BindView(R.id.activity_track_details_scrollview)
     protected NestedScrollView mNestedScrollView;
-    @BindView(R.id.activity_track_details_header_map_container)
     protected FrameLayout mMapViewContainer;
-    @BindView(R.id.consumption_container)
     protected RelativeLayout mConsumptionContainer;
-    @BindView(R.id.co2_container)
     protected RelativeLayout mCo2Container;
-    @BindView(R.id.descriptionTv)
     protected TextView descriptionTv;
-    @BindView(R.id.activity_track_details_speed_container)
     protected RelativeLayout speedLayout;
-    @BindView(R.id.activity_track_details_speed_value)
     protected TextView speedText;
-    @BindView(R.id.activity_track_details_stops_container)
     protected RelativeLayout stopsLayout;
-    @BindView(R.id.activity_track_details_stops_value)
     protected TextView stopsValue;
-    @BindView(R.id.activity_track_details_stoptime_container)
     protected RelativeLayout stoptimeLayout;
-    @BindView(R.id.activity_track_details_stoptime_value)
     protected TextView stoptimeValue;
 
     private Track track;
@@ -175,10 +149,37 @@ public class TrackDetailsActivity extends BaseInjectorActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         initActivityTransition();
-        setContentView(R.layout.activity_track_details_layout);
 
-        // Inject all annotated views.
-        ButterKnife.bind(this);
+        binding = ActivityTrackDetailsLayoutBinding.inflate(getLayoutInflater());
+        final View view = binding.getRoot();
+        setContentView(view);
+
+        mFAB = binding.activityTrackDetailsFab;
+        mMapView = binding.activityTrackDetailsHeaderMap;
+        mToolbar = binding.activityTrackDetailsHeaderToolbar;
+        mDescriptionText = binding.activityTrackDetailsAttrDescriptionValue;
+        mDurationText = binding.activityTrackDetailsAttributesHeader.trackDetailsAttributesHeaderDuration;
+        mDistanceText = binding.activityTrackDetailsAttributesHeader.trackDetailsAttributesHeaderDistance;
+        mBeginText = binding.activityTrackDetailsAttributes.activityTrackDetailsAttrBeginValue;
+        mEndText = binding.activityTrackDetailsAttributes.activityTrackDetailsAttrEndValue;
+        mCarText = binding.activityTrackDetailsAttributes.activityTrackDetailsAttrCarValue;
+        mEmissionKey = binding.activityTrackDetailsAttributes.activityTrackDetailsAttrEmissionText;
+        mEmissionText = binding.activityTrackDetailsAttributes.activityTrackDetailsAttrEmissionValue;
+        mConsumptionKey = binding.activityTrackDetailsAttributes.activityTrackDetailsAttrConsumptionText;
+        mConsumptionText = binding.activityTrackDetailsAttributes.activityTrackDetailsAttrConsumptionValue;
+        mAppBarLayout = binding.activityTrackDetailsAppbarLayout;
+        mNestedScrollView = binding.activityTrackDetailsScrollview;
+        mMapViewContainer = binding.activityTrackDetailsHeaderMapContainer;
+        mConsumptionContainer = binding.activityTrackDetailsAttributes.consumptionContainer;
+        mCo2Container = binding.activityTrackDetailsAttributes.co2Container;
+        descriptionTv = binding.activityTrackDetailsAttributes.descriptionTv;
+        speedLayout = binding.activityTrackDetailsAttributes.activityTrackDetailsSpeedContainer;
+        speedText = binding.activityTrackDetailsAttributes.activityTrackDetailsSpeedValue;
+        stopsLayout = binding.activityTrackDetailsAttributes.activityTrackDetailsStopsContainer;
+        stopsValue = binding.activityTrackDetailsAttributes.activityTrackDetailsStopsValue;
+        stoptimeLayout = binding.activityTrackDetailsAttributes.activityTrackDetailsStoptimeContainer;
+        stoptimeValue = binding.activityTrackDetailsAttributes.activityTrackDetailsStoptimeValue;
+
         mMapView.onCreate(savedInstanceState);
         supportPostponeEnterTransition();
 

--- a/org.envirocar.app/src/org/envirocar/app/views/trackdetails/TrackStatisticsActivity.java
+++ b/org.envirocar.app/src/org/envirocar/app/views/trackdetails/TrackStatisticsActivity.java
@@ -34,6 +34,8 @@ import android.view.ViewGroup;
 
 import org.envirocar.app.BaseApplicationComponent;
 import org.envirocar.app.R;
+import org.envirocar.app.databinding.ActivityTrackStatisticsFragmentBinding;
+import org.envirocar.app.databinding.ActivityTrackStatisticsLayoutBinding;
 import org.envirocar.core.entity.Measurement;
 import org.envirocar.core.entity.Track;
 import org.envirocar.app.injection.BaseInjectorActivity;
@@ -45,8 +47,6 @@ import java.util.concurrent.TimeUnit;
 
 import javax.inject.Inject;
 
-import butterknife.ButterKnife;
-import butterknife.BindView;
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.schedulers.Schedulers;
 import lecho.lib.hellocharts.formatter.SimpleAxisValueFormatter;
@@ -75,10 +75,11 @@ public class TrackStatisticsActivity extends BaseInjectorActivity {
         activity.startActivity(intent);
     }
 
+    private ActivityTrackStatisticsLayoutBinding binding;
+
     @Inject
     protected EnviroCarDB enviroCarDB;
 
-    @BindView(R.id.activity_track_statistics_toolbar)
     protected Toolbar mToolbar;
 
     private Track mTrack;
@@ -92,7 +93,12 @@ public class TrackStatisticsActivity extends BaseInjectorActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        setContentView(R.layout.activity_track_statistics_layout);
+
+        binding = ActivityTrackStatisticsLayoutBinding.inflate(getLayoutInflater());
+        final View view = binding.getRoot();
+        setContentView(view);
+
+        mToolbar = binding.activityTrackStatisticsToolbar;
 
         int trackID = getIntent().getIntExtra(EXTRA_TRACKID, -1);
         Track.TrackId trackid = new Track.TrackId(trackID);
@@ -115,9 +121,6 @@ public class TrackStatisticsActivity extends BaseInjectorActivity {
                     AndroidSchedulers.mainThread().createWorker().schedule(
                             () -> inflateMenuProperties(track), 100, TimeUnit.MILLISECONDS);
                 });
-
-        // Inject all annotated views.
-        ButterKnife.bind(this);
 
         // Initializes the Toolbar.
         setSupportActionBar(mToolbar);
@@ -164,9 +167,9 @@ public class TrackStatisticsActivity extends BaseInjectorActivity {
 
     public static class PlaceholderFragment extends Fragment {
 
-        @BindView(R.id.activity_track_statistics_fragment_chart)
+        private ActivityTrackStatisticsFragmentBinding binding;
+
         protected LineChartView mChart;
-        @BindView(R.id.activity_track_statistics_fragment_chart_preview)
         protected PreviewLineChartView mPreviewChart;
 
         private LineChartData mChartData;
@@ -187,11 +190,11 @@ public class TrackStatisticsActivity extends BaseInjectorActivity {
         @Override
         public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle
                 savedInstanceState) {
-            View rootView = inflater.inflate(R.layout.activity_track_statistics_fragment,
-                    container, false);
+            binding = ActivityTrackStatisticsFragmentBinding.inflate(inflater, container, false);
+            final View rootView = binding.getRoot();
 
-            // Inject all annotated views.
-            ButterKnife.bind(this, rootView);
+            mChart = binding.activityTrackStatisticsFragmentChart;
+            mPreviewChart = binding.activityTrackStatisticsFragmentChartPreview;
 
             if(mTrack.hasProperty(Measurement.PropertyKey.SPEED)){
                 generateData(Measurement.PropertyKey.SPEED);

--- a/org.envirocar.app/src/org/envirocar/app/views/tracklist/AbstractTrackListCardAdapter.java
+++ b/org.envirocar.app/src/org/envirocar/app/views/tracklist/AbstractTrackListCardAdapter.java
@@ -38,6 +38,8 @@ import com.mapbox.mapboxsdk.maps.OnMapReadyCallback;
 import com.mapbox.mapboxsdk.maps.Style;
 
 import org.envirocar.app.R;
+import org.envirocar.app.databinding.FragmentTracklistCardlayoutBinding;
+import org.envirocar.app.databinding.FragmentTracklistCardlayoutRemoteBinding;
 import org.envirocar.app.views.trackdetails.TrackMapLayer;
 import org.envirocar.core.entity.Track;
 import org.envirocar.core.logging.Logger;
@@ -50,8 +52,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.TimeZone;
 
-import butterknife.BindView;
-import butterknife.ButterKnife;
 import io.reactivex.Scheduler;
 import io.reactivex.android.schedulers.AndroidSchedulers;
 
@@ -125,11 +125,11 @@ public abstract class AbstractTrackListCardAdapter<E extends
 
 
     protected void bindLocalTrackViewHolder(TrackCardViewHolder holder, Track track) {
-        holder.mDistance.setText("...");
-        holder.mDuration.setText("...");
+        holder.getDistance().setText("...");
+        holder.getDuration().setText("...");
         LOG.info("bindLocalTrackViewHolder()");
         // First, load the track from the dataset
-        holder.mTitleTextView.setText(track.getName());
+        holder.getTitleTextView().setText(track.getName());
 
         // Initialize the mapView.
         initMapView(holder, track);
@@ -142,20 +142,20 @@ public abstract class AbstractTrackListCardAdapter<E extends
                 try {
                     String date = UTC_DATE_FORMATTER.format(new Date(
                             track.getDuration()));
-                    mMainThreadWorker.schedule(() -> holder.mDuration.setText(date));
+                    mMainThreadWorker.schedule(() -> holder.getDuration().setText(date));
 
                     // Set the tracklength parameter.
 
                     double distanceOfTrack = track.getLength();
                     String tracklength = String.format("%s km", DECIMAL_FORMATTER_TWO.format(
                             distanceOfTrack));
-                    mMainThreadWorker.schedule(() -> holder.mDistance.setText(tracklength));
+                    mMainThreadWorker.schedule(() -> holder.getDistance().setText(tracklength));
 
                 } catch (Exception e) {
                     LOG.warn(e.getMessage(), e);
                     mMainThreadWorker.schedule(() -> {
-                        holder.mDistance.setText("0 km");
-                        holder.mDuration.setText("0:00");
+                        holder.getDistance().setText("0 km");
+                        holder.getDuration().setText("0:00");
                     });
                 }
 
@@ -164,47 +164,43 @@ public abstract class AbstractTrackListCardAdapter<E extends
         }.execute();
 
         // if the menu is not already inflated, then..
-        if (!holder.mToolbar.getMenu().hasVisibleItems()) {
+        if (!holder.getToolbar().getMenu().hasVisibleItems()) {
             // Inflate the menu and set an appropriate OnMenuItemClickListener.
-            holder.mToolbar.inflateMenu(R.menu.menu_tracklist_cardlayout);
+            holder.getToolbar().inflateMenu(R.menu.menu_tracklist_cardlayout);
             if (track.isRemoteTrack()) {
-                holder.mToolbar.getMenu().removeItem(R.id.menu_tracklist_cardlayout_item_upload);
+                holder.getToolbar().getMenu().removeItem(R.id.menu_tracklist_cardlayout_item_upload);
             }
         }
 
-        holder.mToolbar.setOnMenuItemClickListener(item -> {
+        holder.getToolbar().setOnMenuItemClickListener(item -> {
             LOG.info("Item clicked for track " + track.getTrackID());
 
-            switch (item.getItemId()) {
-                case R.id.menu_tracklist_cardlayout_item_details:
-                    mTrackInteractionCallback.onTrackDetailsClicked(track, holder.mMapView);
-                    break;
-                case R.id.menu_tracklist_cardlayout_item_delete:
-                    mTrackInteractionCallback.onDeleteTrackClicked(track);
-                    break;
-                case R.id.menu_tracklist_cardlayout_item_share:
-                    mTrackInteractionCallback.onShareTrackClicked(track);
-                    break;
-                case R.id.menu_tracklist_cardlayout_item_upload:
-                    mTrackInteractionCallback.onUploadTrackClicked(track);
-                    break;
+            if (item.getItemId() == R.id.menu_tracklist_cardlayout_item_details) {
+                mTrackInteractionCallback.onTrackDetailsClicked(track, holder.getMapView());
+            } else if (item.getItemId() == R.id.menu_tracklist_cardlayout_item_delete) {
+                mTrackInteractionCallback.onDeleteTrackClicked(track);
+            } else if (item.getItemId() == R.id.menu_tracklist_cardlayout_item_share) {
+                mTrackInteractionCallback.onShareTrackClicked(track);
+            } else if (item.getItemId() == R.id.menu_tracklist_cardlayout_item_upload) {
+                mTrackInteractionCallback.onUploadTrackClicked(track);
             }
+
             return false;
         });
 
         // Initialize the OnClickListener for the invisible button that is overlaid
         // over the map view.
-        holder.mInvisMapButton.setOnClickListener(v -> {
+        holder.getInvisMapButton().setOnClickListener(v -> {
             LOG.info("Clicked on the map. Navigate to the details activity");
-            mTrackInteractionCallback.onTrackDetailsClicked(track, holder.mMapView);
+            mTrackInteractionCallback.onTrackDetailsClicked(track, holder.getMapView());
         });
 
-        holder.cardViewLayout.setOnLongClickListener(view -> {
+        holder.getCardViewLayout().setOnLongClickListener(view -> {
             mTrackInteractionCallback.onLongPressedTrack(track);
             return true;
         });
 
-        holder.mInvisMapButton.setOnLongClickListener(view -> {
+        holder.getInvisMapButton().setOnLongClickListener(view -> {
             mTrackInteractionCallback.onLongPressedTrack(track);
             return true;
         });
@@ -219,8 +215,8 @@ public abstract class AbstractTrackListCardAdapter<E extends
         LOG.info("initMapView()");
         TrackMapLayer trackMapOverlay = new TrackMapLayer(track);
         final LatLngBounds viewBbox = trackMapOverlay.getViewBoundingBox();
-        holder.mMapView.addOnDidFailLoadingMapListener(holder.failLoadingMapListener);
-        holder.mMapView.getMapAsync(new OnMapReadyCallback() {
+        holder.getMapView().addOnDidFailLoadingMapListener(holder.failLoadingMapListener);
+        holder.getMapView().getMapAsync(new OnMapReadyCallback() {
             @Override
             public void onMapReady(@NonNull MapboxMap tep) {
                 LOG.info("onMapReady()");
@@ -243,15 +239,15 @@ public abstract class AbstractTrackListCardAdapter<E extends
     @Override
     public void onViewAttachedToWindow(@NonNull E holder) {
         super.onViewAttachedToWindow(holder);
-        holder.mMapView.onStart();
-        holder.mMapView.onResume();
+        holder.getMapView().onStart();
+        holder.getMapView().onResume();
     }
 
     @Override
     public void onViewDetachedFromWindow(@NonNull E holder) {
         super.onViewDetachedFromWindow(holder);
-        holder.mMapView.onPause();
-        holder.mMapView.onStop();
+        holder.getMapView().onPause();
+        holder.getMapView().onStop();
     }
 
 //    private void initRouteCoordinates(Track track) {
@@ -295,38 +291,20 @@ public abstract class AbstractTrackListCardAdapter<E extends
     /**
      *
      */
-    static class TrackCardViewHolder extends RecyclerView.ViewHolder {
-
-        protected final View mItemView;
-
-        @BindView(R.id.fragment_tracklist_cardlayout_toolbar)
-        protected Toolbar mToolbar;
-        @BindView(R.id.fragment_tracklist_cardlayout_toolbar_title)
-        protected TextView mTitleTextView;
-        @BindView(R.id.fragment_tracklist_cardlayout_content)
-        protected View mContentView;
-        @BindView(R.id.track_details_attributes_header_distance)
-        protected TextView mDistance;
-        @BindView(R.id.track_details_attributes_header_duration)
-        protected TextView mDuration;
-        @BindView(R.id.fragment_tracklist_cardlayout_map)
-        protected MapView mMapView;
-        @BindView(R.id.fragment_tracklist_cardlayout_invis_mapbutton)
-        protected ImageButton mInvisMapButton;
-        @BindView(R.id.fragment_layout_card_view)
-        protected LinearLayout cardViewLayout;
-
+    static abstract class TrackCardViewHolder extends RecyclerView.ViewHolder {
         protected MapView.OnDidFailLoadingMapListener failLoadingMapListener;
 
-        /**
-         * Constructor.
-         *
-         * @param itemView the card view of the
-         */
+        abstract Toolbar getToolbar();
+        abstract TextView getTitleTextView();
+        abstract View getContentView();
+        abstract TextView getDistance();
+        abstract TextView getDuration();
+        abstract MapView getMapView();
+        abstract ImageButton getInvisMapButton();
+        abstract LinearLayout getCardViewLayout();
+
         public TrackCardViewHolder(View itemView) {
             super(itemView);
-            this.mItemView = itemView;
-            ButterKnife.bind(this, itemView);
             failLoadingMapListener = new MapView.OnDidFailLoadingMapListener() {
                 @Override
                 public void onDidFailLoadingMap(String errorMessage) {
@@ -340,14 +318,51 @@ public abstract class AbstractTrackListCardAdapter<E extends
      * Default view holder for standard local and not uploaded tracks.
      */
     static class LocalTrackCardViewHolder extends TrackCardViewHolder {
+        FragmentTracklistCardlayoutBinding binding;
 
-        /**
-         * Constructor.
-         *
-         * @param itemView
-         */
-        public LocalTrackCardViewHolder(View itemView) {
-            super(itemView);
+        @Override
+        Toolbar getToolbar() {
+            return binding.fragmentTracklistCardlayoutToolbar;
+        }
+
+        @Override
+        TextView getTitleTextView() {
+            return binding.fragmentTracklistCardlayoutToolbarTitle;
+        }
+
+        @Override
+        View getContentView() {
+            return binding.fragmentTracklistCardlayoutContent.fragmentTracklistCardlayoutContent;
+        }
+
+        @Override
+        TextView getDistance() {
+            return binding.fragmentTracklistCardlayoutContent.trackDetailsAttributesHeaderDistance;
+        }
+
+        @Override
+        TextView getDuration() {
+            return binding.fragmentTracklistCardlayoutContent.trackDetailsAttributesHeaderDuration;
+        }
+
+        @Override
+        MapView getMapView() {
+            return binding.fragmentTracklistCardlayoutContent.fragmentTracklistCardlayoutMap;
+        }
+
+        @Override
+        ImageButton getInvisMapButton() {
+            return binding.fragmentTracklistCardlayoutContent.fragmentTracklistCardlayoutInvisMapbutton;
+        }
+
+        @Override
+        LinearLayout getCardViewLayout() {
+            return binding.fragmentLayoutCardView;
+        }
+
+        public LocalTrackCardViewHolder(FragmentTracklistCardlayoutBinding binding) {
+            super(binding.getRoot());
+            this.binding = binding;
         }
     }
 
@@ -356,21 +371,63 @@ public abstract class AbstractTrackListCardAdapter<E extends
      * of a remote track list. (i.e. users/{getUserStatistic}/tracks)
      */
     static class RemoteTrackCardViewHolder extends TrackCardViewHolder {
+        FragmentTracklistCardlayoutRemoteBinding binding;
 
-        @BindView(R.id.fragment_tracklist_cardlayout_remote_progresscircle)
-        protected FABProgressCircle mProgressCircle;
-        @BindView(R.id.fragment_tracklist_cardlayout_remote_downloadfab)
-        protected FloatingActionButton mDownloadButton;
-        @BindView(R.id.fragment_tracklist_cardlayout_downloading_notification)
-        protected TextView mDownloadNotification;
+        @Override
+        Toolbar getToolbar() {
+            return binding.fragmentTracklistCardlayoutToolbar;
+        }
 
-        /**
-         * Constructor.
-         *
-         * @param itemView the card view of the
-         */
-        public RemoteTrackCardViewHolder(View itemView) {
-            super(itemView);
+        @Override
+        TextView getTitleTextView() {
+            return binding.fragmentTracklistCardlayoutToolbarTitle;
+        }
+
+        @Override
+        View getContentView() {
+            return binding.fragmentTracklistCardlayoutContent.fragmentTracklistCardlayoutContent;
+        }
+
+        @Override
+        TextView getDistance() {
+            return binding.fragmentTracklistCardlayoutContent.trackDetailsAttributesHeaderDistance;
+        }
+
+        @Override
+        TextView getDuration() {
+            return binding.fragmentTracklistCardlayoutContent.trackDetailsAttributesHeaderDuration;
+        }
+
+        @Override
+        MapView getMapView() {
+            return binding.fragmentTracklistCardlayoutContent.fragmentTracklistCardlayoutMap;
+        }
+
+        @Override
+        ImageButton getInvisMapButton() {
+            return binding.fragmentTracklistCardlayoutContent.fragmentTracklistCardlayoutInvisMapbutton;
+        }
+
+        @Override
+        LinearLayout getCardViewLayout() {
+            return binding.fragmentLayoutCardView;
+        }
+
+        FABProgressCircle getProgressCircle() {
+            return binding.fragmentTracklistCardlayoutRemoteProgresscircle;
+        }
+
+        FloatingActionButton getDownloadButton() {
+            return binding.fragmentTracklistCardlayoutRemoteDownloadfab;
+        }
+
+        TextView getDownloadNotification() {
+            return binding.fragmentTracklistCardlayoutDownloadingNotification;
+        }
+
+        public RemoteTrackCardViewHolder(FragmentTracklistCardlayoutRemoteBinding binding) {
+            super(binding.getRoot());
+            this.binding = binding;
         }
     }
 }

--- a/org.envirocar.app/src/org/envirocar/app/views/tracklist/AbstractTrackListCardFragment.java
+++ b/org.envirocar.app/src/org/envirocar/app/views/tracklist/AbstractTrackListCardFragment.java
@@ -18,7 +18,6 @@
  */
 package org.envirocar.app.views.tracklist;
 
-import android.Manifest;
 import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.net.Uri;
@@ -33,7 +32,6 @@ import android.widget.TextView;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.core.app.ActivityCompat;
 import androidx.core.content.FileProvider;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
@@ -44,20 +42,21 @@ import com.google.android.material.snackbar.Snackbar;
 
 import org.envirocar.app.BuildConfig;
 import org.envirocar.app.R;
+import org.envirocar.app.databinding.FragmentTracklistBinding;
 import org.envirocar.app.handler.DAOProvider;
 import org.envirocar.app.handler.TrackDAOHandler;
 import org.envirocar.app.handler.TrackUploadHandler;
-import org.envirocar.app.handler.preferences.UserPreferenceHandler;
 import org.envirocar.app.handler.agreement.AgreementManager;
+import org.envirocar.app.handler.preferences.UserPreferenceHandler;
 import org.envirocar.app.injection.BaseInjectorFragment;
 import org.envirocar.app.views.utils.ECAnimationUtils;
+import org.envirocar.core.EnviroCarDB;
 import org.envirocar.core.entity.Track;
 import org.envirocar.core.exception.NotConnectedException;
 import org.envirocar.core.exception.UnauthorizedException;
 import org.envirocar.core.logging.Logger;
 import org.envirocar.core.util.FileWithMetadata;
 import org.envirocar.remote.serde.TrackSerde;
-import org.envirocar.core.EnviroCarDB;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -66,8 +65,6 @@ import java.util.List;
 
 import javax.inject.Inject;
 
-import butterknife.BindView;
-import butterknife.ButterKnife;
 import io.reactivex.Observable;
 import io.reactivex.Scheduler;
 import io.reactivex.android.schedulers.AndroidSchedulers;
@@ -79,6 +76,8 @@ import io.reactivex.schedulers.Schedulers;
  */
 public abstract class AbstractTrackListCardFragment<E extends RecyclerView.Adapter> extends BaseInjectorFragment {
     private static final Logger LOG = Logger.getLogger(AbstractTrackListCardFragment.class);
+
+    private FragmentTracklistBinding binding;
 
     @Inject
     protected UserPreferenceHandler mUserManager;
@@ -93,24 +92,15 @@ public abstract class AbstractTrackListCardFragment<E extends RecyclerView.Adapt
     @Inject
     protected TrackUploadHandler mTrackUploadHandler;
 
-    @BindView(R.id.fragment_tracklist_info)
     protected View infoView;
-    @BindView(R.id.fragment_tracklist_info_img)
     protected ImageView infoImg;
-    @BindView(R.id.fragment_tracklist_info_text)
     protected TextView infoText;
-    @BindView(R.id.fragment_tracklist_info_subtext)
     protected TextView infoSubtext;
 
-    @BindView(R.id.fragment_tracklist_progress_view)
     protected View mProgressView;
-    @BindView(R.id.fragment_tracklist_progress_text)
     protected TextView mProgressText;
-    @BindView(R.id.fragment_tracklist_progress_progressBar)
     protected ProgressBar mProgressBar;
-    @BindView(R.id.fragment_tracklist_recycler_view)
     protected RecyclerView mRecyclerView;
-    @BindView(R.id.fragment_tracklist_fab)
     protected FloatingActionButton mFAB;
 
     protected E mRecyclerViewAdapter;
@@ -134,9 +124,18 @@ public abstract class AbstractTrackListCardFragment<E extends RecyclerView.Adapt
             savedInstanceState) {
         super.onCreateView(inflater, container, savedInstanceState);
 
-        // Inflate the view and inject the annotated view.
-        View view = inflater.inflate(R.layout.fragment_tracklist, container, false);
-        ButterKnife.bind(this, view);
+        binding = FragmentTracklistBinding.inflate(inflater, container, false);
+        final View view = binding.getRoot();
+
+        infoView = binding.fragmentTracklistInfo.getRoot();
+        infoImg = binding.fragmentTracklistInfo.fragmentTracklistInfoImg;
+        infoText = binding.fragmentTracklistInfo.fragmentTracklistInfoText;
+        infoSubtext = binding.fragmentTracklistInfo.fragmentTracklistInfoSubtext;
+        mProgressView = binding.fragmentTracklistProgressView;
+        mProgressText = binding.fragmentTracklistProgressText;
+        mProgressBar = binding.fragmentTracklistProgressProgressBar;
+        mRecyclerView = binding.fragmentTracklistRecyclerView;
+        mFAB = binding.fragmentTracklistFab;
 
         // Initiate the recyclerview
 //        mRecyclerView.setHasFixedSize(true);
@@ -154,6 +153,12 @@ public abstract class AbstractTrackListCardFragment<E extends RecyclerView.Adapt
         }
 
         return view;
+    }
+
+    @Override
+    public void onDestroyView() {
+        super.onDestroyView();
+        binding = null;
     }
 
     /**

--- a/org.envirocar.app/src/org/envirocar/app/views/tracklist/TrackListLocalCardAdapter.java
+++ b/org.envirocar.app/src/org/envirocar/app/views/tracklist/TrackListLocalCardAdapter.java
@@ -1,30 +1,29 @@
 /**
  * Copyright (C) 2013 - 2021 the enviroCar community
- *
+ * <p>
  * This file is part of the enviroCar app.
- *
+ * <p>
  * The enviroCar app is free software: you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as published
  * by the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- *
+ * <p>
  * The enviroCar app is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
  * Public License for more details.
- *
+ * <p>
  * You should have received a copy of the GNU General Public License along
  * with the enviroCar app. If not, see http://www.gnu.org/licenses/.
  */
 package org.envirocar.app.views.tracklist;
 
 import android.view.LayoutInflater;
-import android.view.View;
 import android.view.ViewGroup;
 
 import com.mapbox.mapboxsdk.maps.MapView;
 
-import org.envirocar.app.R;
+import org.envirocar.app.databinding.FragmentTracklistCardlayoutBinding;
 import org.envirocar.core.entity.Track;
 import org.envirocar.core.logging.Logger;
 
@@ -51,18 +50,15 @@ public class TrackListLocalCardAdapter extends AbstractTrackListCardAdapter<
     protected List<MapView> mapViews = new ArrayList<>();
 
     @Override
-    public TrackListLocalCardAdapter.LocalTrackCardViewHolder onCreateViewHolder(
-            ViewGroup parent, int viewType) {
-
-        // First inflate the view.
-        View view = LayoutInflater.from(parent.getContext()).inflate(R.layout
-                .fragment_tracklist_cardlayout, parent, false);
-
-        // then return a new view holder for the inflated view.
-        LocalTrackCardViewHolder temp = new LocalTrackCardViewHolder(view);
-
-        mapViews.add(temp.mMapView);
-        return temp;
+    public TrackListLocalCardAdapter.LocalTrackCardViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
+        final FragmentTracklistCardlayoutBinding binding = FragmentTracklistCardlayoutBinding.inflate(
+                LayoutInflater.from(parent.getContext()),
+                parent,
+                false
+        );
+        LocalTrackCardViewHolder holder = new LocalTrackCardViewHolder(binding);
+        mapViews.add(holder.getMapView());
+        return holder;
     }
 
     @Override
@@ -70,13 +66,13 @@ public class TrackListLocalCardAdapter extends AbstractTrackListCardAdapter<
         bindLocalTrackViewHolder(holder, mTrackDataset.get(position));
     }
 
-    public void onLowMemory(){
-        for(MapView mapView : mapViews){
+    public void onLowMemory() {
+        for (MapView mapView : mapViews) {
             mapView.onLowMemory();
         }
     }
 
-    public void onDestroy(){
+    public void onDestroy() {
         for (MapView mapView : mapViews) {
             mapView.onPause();
             mapView.onStop();

--- a/org.envirocar.app/src/org/envirocar/app/views/tracklist/TrackListLocalCardFragment.java
+++ b/org.envirocar.app/src/org/envirocar/app/views/tracklist/TrackListLocalCardFragment.java
@@ -21,7 +21,9 @@ package org.envirocar.app.views.tracklist;
 import android.content.DialogInterface;
 import android.os.AsyncTask;
 import android.os.Bundle;
+import android.view.LayoutInflater;
 import android.view.View;
+import android.view.ViewGroup;
 import android.widget.ProgressBar;
 import android.widget.TextView;
 
@@ -56,7 +58,6 @@ import java.util.List;
 
 import javax.inject.Inject;
 
-import butterknife.OnClick;
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.observers.DisposableObserver;
@@ -120,7 +121,6 @@ public class TrackListLocalCardFragment extends AbstractTrackListCardFragment<Tr
         mRecyclerViewAdapter.onDestroy();
     }
 
-    @OnClick(R.id.fragment_tracklist_fab)
     protected void onUploadTracksFABClicked() {
         new MaterialAlertDialogBuilder(getContext(), R.style.MaterialDialog)
                 .setTitle(R.string.track_list_upload_all_tracks_title)
@@ -223,6 +223,14 @@ public class TrackListLocalCardFragment extends AbstractTrackListCardFragment<Tr
                 showNoTracksInfo();
             }
         });
+    }
+
+    @Nullable
+    @Override
+    public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+        final View view = super.onCreateView(inflater, container, savedInstanceState);
+        mFAB.setOnClickListener(v -> onUploadTracksFABClicked());
+        return view;
     }
 
     @Override

--- a/org.envirocar.app/src/org/envirocar/app/views/tracklist/TrackListPagerFragment.java
+++ b/org.envirocar.app/src/org/envirocar/app/views/tracklist/TrackListPagerFragment.java
@@ -32,12 +32,11 @@ import androidx.viewpager.widget.ViewPager;
 import org.envirocar.app.BaseApplication;
 import org.envirocar.app.BaseApplicationComponent;
 import org.envirocar.app.R;
+import org.envirocar.app.databinding.FragmentTracklistLayoutBinding;
 import org.envirocar.app.injection.BaseInjectorFragment;
 import org.envirocar.app.injection.modules.MainActivityModule;
 import org.envirocar.core.logging.Logger;
 
-import butterknife.BindView;
-import butterknife.ButterKnife;
 import info.hoang8f.android.segmented.SegmentedGroup;
 
 /**
@@ -46,9 +45,9 @@ import info.hoang8f.android.segmented.SegmentedGroup;
 public class TrackListPagerFragment extends BaseInjectorFragment {
     private static final Logger LOG = Logger.getLogger(TrackListPagerFragment.class);
 
-    @BindView(R.id.trackListSegmentedGroup)
+    private FragmentTracklistLayoutBinding binding;
+
     protected SegmentedGroup trackListSegmentedGroup;
-    @BindView(R.id.fragment_tracklist_layout_viewpager)
     protected ViewPager mViewPager;
 
     private TrackListPagerAdapter trackListPageAdapter;
@@ -65,8 +64,11 @@ public class TrackListPagerFragment extends BaseInjectorFragment {
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         LOG.info("onCreateView()");
-        View content = inflater.inflate(R.layout.fragment_tracklist_layout, container, false);
-        ButterKnife.bind(this, content);
+        binding = FragmentTracklistLayoutBinding.inflate(inflater, container, false);
+        View content = binding.getRoot();
+
+        trackListSegmentedGroup = binding.trackListSegmentedGroup;
+        mViewPager = binding.fragmentTracklistLayoutViewpager;
 
         trackListPageAdapter = new TrackListPagerAdapter(getChildFragmentManager());
         mViewPager.setAdapter(trackListPageAdapter);
@@ -95,15 +97,10 @@ public class TrackListPagerFragment extends BaseInjectorFragment {
         trackListSegmentedGroup.check(R.id.localSegmentedButton);
 
         trackListSegmentedGroup.setOnCheckedChangeListener((radioGroup, i) -> {
-            switch (i) {
-                case R.id.localSegmentedButton:
-                    mViewPager.setCurrentItem(0);
-                    break;
-                case R.id.uploadedSegmentedButton:
-                    mViewPager.setCurrentItem(1);
-                    break;
-                default:
-                    break;
+            if (i == R.id.localSegmentedButton) {
+                mViewPager.setCurrentItem(0);
+            } else if (i == R.id.uploadedSegmentedButton) {
+                mViewPager.setCurrentItem(1);
             }
         });
 

--- a/org.envirocar.app/src/org/envirocar/app/views/tracklist/TrackListRemoteCardAdapter.java
+++ b/org.envirocar.app/src/org/envirocar/app/views/tracklist/TrackListRemoteCardAdapter.java
@@ -24,7 +24,7 @@ import android.view.ViewGroup;
 
 import com.mapbox.mapboxsdk.maps.MapView;
 
-import org.envirocar.app.R;
+import org.envirocar.app.databinding.FragmentTracklistCardlayoutRemoteBinding;
 import org.envirocar.core.entity.Track;
 import org.envirocar.core.logging.Logger;
 
@@ -52,14 +52,14 @@ public class TrackListRemoteCardAdapter extends AbstractTrackListCardAdapter<
 
     @Override
     public RemoteTrackCardViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
-        // Inflate the content view of the card.
-        View remoteView = LayoutInflater.from(parent.getContext())
-                .inflate(R.layout.fragment_tracklist_cardlayout_remote, parent, false);
-
-        // and create a new viewholder.
-        RemoteTrackCardViewHolder temp = new RemoteTrackCardViewHolder(remoteView);
-        mapViews.add(temp.mMapView);
-        return temp;
+        final FragmentTracklistCardlayoutRemoteBinding binding = FragmentTracklistCardlayoutRemoteBinding.inflate(
+                LayoutInflater.from(parent.getContext()),
+                parent,
+                false
+        );
+        RemoteTrackCardViewHolder holder = new RemoteTrackCardViewHolder(binding);
+        mapViews.add(holder.getMapView());
+        return holder;
     }
 
     @Override
@@ -69,39 +69,39 @@ public class TrackListRemoteCardAdapter extends AbstractTrackListCardAdapter<
         final Track remoteTrack = mTrackDataset.get(position);
 
         // Reset the most important settings of the views.
-        holder.mTitleTextView.setText(remoteTrack.getName());
-        holder.mDownloadButton.setOnClickListener(null);
-        holder.mMapView.onCreate(null);
-        holder.mMapView.removeOnDidFailLoadingMapListener(holder.failLoadingMapListener);
-        holder.mToolbar.getMenu().clear();
+        holder.getTitleTextView().setText(remoteTrack.getName());
+        holder.getDownloadButton().setOnClickListener(null);
+        holder.getMapView().onCreate(null);
+        holder.getMapView().removeOnDidFailLoadingMapListener(holder.failLoadingMapListener);
+        holder.getToolbar().getMenu().clear();
         // Depending on the tracks state
         switch (remoteTrack.getDownloadState()) {
             case REMOTE:
-                holder.mContentView.setVisibility(View.GONE);
-                holder.mProgressCircle.setVisibility(View.VISIBLE);
+                holder.getContentView().setVisibility(View.GONE);
+                holder.getProgressCircle().setVisibility(View.VISIBLE);
 
                 // Workaround: Sometimes the inner arcview can be null when set visible
-                holder.mProgressCircle.post(() -> {
+                holder.getProgressCircle().post(() -> {
                     //holder.mProgressCircle.hide();
                 });
-                holder.mDownloadButton.show();
-                holder.mDownloadButton.setOnClickListener(v -> {
-                    holder.mDownloadButton.setOnClickListener(null);
+                holder.getDownloadButton().show();
+                holder.getDownloadButton().setOnClickListener(v -> {
+                    holder.getDownloadButton().setOnClickListener(null);
                     mTrackInteractionCallback.onDownloadTrackClicked(remoteTrack, holder);
                 });
-                holder.mDownloadNotification.setVisibility(View.GONE);
+                holder.getDownloadNotification().setVisibility(View.GONE);
                 break;
             case DOWNLOADING:
-                holder.mContentView.setVisibility(View.GONE);
-                holder.mProgressCircle.setVisibility(View.VISIBLE);
-                holder.mProgressCircle.post(() -> holder.mProgressCircle.show());
-                holder.mDownloadButton.show();
-                holder.mDownloadNotification.setVisibility(View.VISIBLE);
+                holder.getContentView().setVisibility(View.GONE);
+                holder.getProgressCircle().setVisibility(View.VISIBLE);
+                holder.getProgressCircle().post(() -> holder.getProgressCircle().show());
+                holder.getDownloadButton().show();
+                holder.getDownloadNotification().setVisibility(View.VISIBLE);
                 break;
             case DOWNLOADED:
-                holder.mContentView.setVisibility(View.VISIBLE);
-                holder.mProgressCircle.setVisibility(View.GONE);
-                holder.mDownloadNotification.setVisibility(View.GONE);
+                holder.getContentView().setVisibility(View.VISIBLE);
+                holder.getProgressCircle().setVisibility(View.GONE);
+                holder.getDownloadNotification().setVisibility(View.GONE);
                 bindLocalTrackViewHolder(holder, remoteTrack);
                 break;
         }

--- a/org.envirocar.app/src/org/envirocar/app/views/tracklist/TrackListRemoteCardFragment.java
+++ b/org.envirocar.app/src/org/envirocar/app/views/tracklist/TrackListRemoteCardFragment.java
@@ -196,9 +196,9 @@ public class TrackListRemoteCardFragment extends AbstractTrackListCardFragment<T
                 (AbstractTrackListCardAdapter.RemoteTrackCardViewHolder) viewHolder;
 
         // Show the downloading text notification.
-        ECAnimationUtils.animateShowView(getActivity(), holder.mDownloadNotification,
+        ECAnimationUtils.animateShowView(getActivity(), holder.getDownloadNotification(),
                 R.anim.fade_in);
-        holder.mProgressCircle.show();
+        holder.getProgressCircle().show();
         track.setDownloadState(Track.DownloadState.DOWNLOADING);
 
         mTrackDAOHandler.fetchRemoteTrackObservable(track)
@@ -208,17 +208,17 @@ public class TrackListRemoteCardFragment extends AbstractTrackListCardFragment<T
 
                     @Override
                     public void onComplete() {
-                        holder.mProgressCircle.beginFinalAnimation();
-                        holder.mProgressCircle.attachListener(() -> {
+                        holder.getProgressCircle().beginFinalAnimation();
+                        holder.getProgressCircle().attachListener(() -> {
                             // When the visualization is finished, then Init the
                             // content view including its mapview and track details.
                             mRecyclerViewAdapter.bindLocalTrackViewHolder(holder, track);
 
                             // and hide the download button
                             ECAnimationUtils.animateHideView(getActivity(), R.anim.fade_out,
-                                    holder.mProgressCircle, holder.mDownloadButton, holder
-                                            .mDownloadNotification);
-                            ECAnimationUtils.animateShowView(getActivity(), holder.mContentView, R
+                                    holder.getProgressCircle(), holder.getDownloadButton(), holder
+                                            .getDownloadNotification());
+                            ECAnimationUtils.animateShowView(getActivity(), holder.getContentView(), R
                                     .anim.fade_in);
                         });
                     }
@@ -227,9 +227,9 @@ public class TrackListRemoteCardFragment extends AbstractTrackListCardFragment<T
                     public void onError(Throwable e) {
                         LOG.error("Not connected exception", e);
                         showSnackbar(R.string.track_list_communication_error);
-                        holder.mProgressCircle.hide();
+                        holder.getProgressCircle().hide();
                         track.setDownloadState(Track.DownloadState.DOWNLOADING);
-                        holder.mDownloadNotification.setText(
+                        holder.getDownloadNotification().setText(
                                 R.string.track_list_error_while_downloading);
                     }
 


### PR DESCRIPTION
[Jetpack View Binding](https://developer.android.com/topic/libraries/view-binding) is the recommended replacement for now deprecated [Butter Knife](https://github.com/JakeWharton/butterknife).

The migration away from [Butter Knife](https://github.com/JakeWharton/butterknife) is necessary in order to run the project on newer Android Studio & JDK versions. A [workaround](https://github.com/enviroCar/enviroCar-app/blob/dc9f95508b1db16b943d8b0a8ef8fdeaa9ea9dd5/gradle.properties#L14-L19) was introduced in #1000, in order to make the project run with [Butter Knife](https://github.com/JakeWharton/butterknife), which has now been removed as part of this pull-request.