### PR TITLE
Utilize `MapProvider` interface inside the application

### DIFF
--- a/org.envirocar.map/src/main/assets/maplibre_default_style.json
+++ b/org.envirocar.map/src/main/assets/maplibre_default_style.json
@@ -1,0 +1,21 @@
+{
+  "version": 8,
+  "sources": {
+    "osm": {
+      "type": "raster",
+      "tiles": [
+        "https://a.tile.openstreetmap.org/{z}/{x}/{y}.png"
+      ],
+      "tileSize": 256,
+      "attribution": "&copy; OpenStreetMap Contributors",
+      "maxzoom": 19
+    }
+  },
+  "layers": [
+    {
+      "id": "osm",
+      "type": "raster",
+      "source": "osm"
+    }
+  ]
+}

--- a/org.envirocar.map/src/main/java/org/envirocar/map/provider/maplibre/MapLibreMapProvider.kt
+++ b/org.envirocar.map/src/main/java/org/envirocar/map/provider/maplibre/MapLibreMapProvider.kt
@@ -5,6 +5,7 @@ import org.envirocar.map.MapController
 import org.envirocar.map.MapProvider
 import org.maplibre.android.MapLibre
 import org.maplibre.android.maps.MapView
+import org.maplibre.android.maps.Style
 
 /**
  * [MapLibreMapProvider]
@@ -22,7 +23,7 @@ import org.maplibre.android.maps.MapView
  * * `file://`
  */
 class MapLibreMapProvider(
-    private val style: String
+    private val style: String = DEFAULT_STYLE
 ) : MapProvider {
     private lateinit var viewInstance: MapView
     private lateinit var controllerInstance: MapLibreMapController
@@ -36,7 +37,7 @@ class MapLibreMapProvider(
         if (!::viewInstance.isInitialized) {
             viewInstance = MapView(context).apply {
                 getMapAsync {
-                    it.setStyle(style)
+                    it.setStyle(Style.Builder().fromUri(style))
                 }
             }
         }
@@ -54,6 +55,8 @@ class MapLibreMapProvider(
     }
 
     companion object {
+        const val DEFAULT_STYLE = "asset://maplibre_default_style.json"
+
         @Volatile
         private var initailized = false
     }


### PR DESCRIPTION
At the moment, application uses `MapboxMapProvider` from the `org.envirocar.map` module directly. It makes sense to use the `MapProvider` interface instead, which will give us ability to switch between different providers.

The change is necessary to allow users to switch between different providers e.g. `MapboxMapProvider`, `MapLibreMapProvider` etc. on runtime.